### PR TITLE
Fix type of CommittedSeal in IsValidCommittedSeal and InsertBlock

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           # Specify a version instead of 'latest'
           # because of something wrong with 1.48.0
-          version: 1.47.3
+          version: v1.47.3
           args:
             --timeout=3m
             -E whitespace

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,9 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: latest
+          # Specify a version instead of 'latest'
+          # because of something wrong with 1.48.0
+          version: 1.47.3
           args:
             --timeout=3m
             -E whitespace
@@ -61,7 +63,7 @@ jobs:
 
       - name: Go test
         run: go test -coverprofile coverage.out -timeout 28m ./...
-      
+
       - name: Upload coverage file to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/core/backend.go
+++ b/core/backend.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"github.com/0xPolygon/go-ibft/messages"
 	"github.com/0xPolygon/go-ibft/messages/proto"
 )
 
@@ -42,7 +43,7 @@ type Verifier interface {
 	IsValidProposalHash(proposal, hash []byte) bool
 
 	// IsValidCommittedSeal checks if the seal for the proposal is valid
-	IsValidCommittedSeal(proposal, seal []byte) bool
+	IsValidCommittedSeal(proposal []byte, committedSeal *messages.CommittedSeal) bool
 }
 
 // Backend defines an interface all backend implementations
@@ -55,7 +56,7 @@ type Backend interface {
 	BuildProposal(blockNumber uint64) []byte
 
 	// InsertBlock inserts a proposal with the specified committed seals
-	InsertBlock(proposal []byte, committedSeals [][]byte)
+	InsertBlock(proposal []byte, committedSeals []*messages.CommittedSeal)
 
 	// ID returns the validator's ID
 	ID() []byte

--- a/core/consensus_test.go
+++ b/core/consensus_test.go
@@ -3,11 +3,13 @@ package core
 import (
 	"bytes"
 	"fmt"
-	"github.com/0xPolygon/go-ibft/messages/proto"
-	"github.com/stretchr/testify/assert"
 	"math"
 	"testing"
 	"time"
+
+	"github.com/0xPolygon/go-ibft/messages"
+	"github.com/0xPolygon/go-ibft/messages/proto"
+	"github.com/stretchr/testify/assert"
 )
 
 // generateNodeAddresses generates dummy node addresses
@@ -189,7 +191,7 @@ func TestConsensus_ValidFlow(t *testing.T) {
 		}
 
 		// Make sure the inserted proposal is noted
-		backend.insertBlockFn = func(proposal []byte, committedSeals [][]byte) {
+		backend.insertBlockFn = func(proposal []byte, _ []*messages.CommittedSeal) {
 			insertedBlocks[nodeIndex] = proposal
 		}
 	}
@@ -375,7 +377,7 @@ func TestConsensus_InvalidBlock(t *testing.T) {
 		}
 
 		// Make sure the inserted proposal is noted
-		backend.insertBlockFn = func(proposal []byte, committedSeals [][]byte) {
+		backend.insertBlockFn = func(proposal []byte, _ []*messages.CommittedSeal) {
 			insertedBlocks[nodeIndex] = proposal
 		}
 	}

--- a/core/ibft.go
+++ b/core/ibft.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"github.com/0xPolygon/go-ibft/messages"
-	"github.com/0xPolygon/go-ibft/messages/proto"
 	"math"
 	"sync"
 	"time"
+
+	"github.com/0xPolygon/go-ibft/messages"
+	"github.com/0xPolygon/go-ibft/messages/proto"
 )
 
 type Logger interface {
@@ -109,7 +110,7 @@ func NewIBFT(
 				Height: 0,
 				Round:  0,
 			},
-			seals:        make([][]byte, 0),
+			seals:        make([]*messages.CommittedSeal, 0),
 			roundStarted: false,
 			name:         newRound,
 		},

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -2,10 +2,11 @@ package core
 
 import (
 	"context"
-	"github.com/0xPolygon/go-ibft/messages"
-	"github.com/0xPolygon/go-ibft/messages/proto"
 	"sync"
 	"time"
+
+	"github.com/0xPolygon/go-ibft/messages"
+	"github.com/0xPolygon/go-ibft/messages/proto"
 )
 
 // Define delegation methods
@@ -14,7 +15,7 @@ type isValidSenderDelegate func(*proto.Message) bool
 type isProposerDelegate func([]byte, uint64, uint64) bool
 type buildProposalDelegate func(uint64) []byte
 type isValidProposalHashDelegate func([]byte, []byte) bool
-type isValidCommittedSealDelegate func([]byte, []byte) bool
+type isValidCommittedSealDelegate func([]byte, *messages.CommittedSeal) bool
 
 type buildPrePrepareMessageDelegate func(
 	[]byte,
@@ -30,7 +31,7 @@ type buildRoundChangeMessageDelegate func(
 ) *proto.Message
 
 type quorumDelegate func(blockHeight uint64) uint64
-type insertBlockDelegate func([]byte, [][]byte)
+type insertBlockDelegate func([]byte, []*messages.CommittedSeal)
 type idDelegate func() []byte
 type maximumFaultyNodesDelegate func() uint64
 
@@ -61,9 +62,9 @@ func (m mockBackend) ID() []byte {
 	return nil
 }
 
-func (m mockBackend) InsertBlock(proposal []byte, seals [][]byte) {
+func (m mockBackend) InsertBlock(proposal []byte, committedSeals []*messages.CommittedSeal) {
 	if m.insertBlockFn != nil {
-		m.insertBlockFn(proposal, seals)
+		m.insertBlockFn(proposal, committedSeals)
 	}
 }
 
@@ -115,9 +116,9 @@ func (m mockBackend) IsValidProposalHash(proposal, hash []byte) bool {
 	return true
 }
 
-func (m mockBackend) IsValidCommittedSeal(proposal, seal []byte) bool {
+func (m mockBackend) IsValidCommittedSeal(proposal []byte, committedSeal *messages.CommittedSeal) bool {
 	if m.isValidCommittedSealFn != nil {
-		return m.isValidCommittedSealFn(proposal, seal)
+		return m.isValidCommittedSealFn(proposal, committedSeal)
 	}
 
 	return true

--- a/core/state.go
+++ b/core/state.go
@@ -1,9 +1,10 @@
 package core
 
 import (
+	"sync"
+
 	"github.com/0xPolygon/go-ibft/messages"
 	"github.com/0xPolygon/go-ibft/messages/proto"
-	"sync"
 )
 
 type stateType uint8
@@ -47,7 +48,7 @@ type state struct {
 	proposalMessage *proto.Message
 
 	//	validated commit seals
-	seals [][]byte
+	seals []*messages.CommittedSeal
 
 	//	flags for different states
 	roundStarted bool
@@ -142,7 +143,7 @@ func (s *state) getProposal() []byte {
 	return nil
 }
 
-func (s *state) getCommittedSeals() [][]byte {
+func (s *state) getCommittedSeals() []*messages.CommittedSeal {
 	s.RLock()
 	defer s.RUnlock()
 
@@ -177,7 +178,7 @@ func (s *state) setView(view *proto.View) {
 	s.view = view
 }
 
-func (s *state) setCommittedSeals(seals [][]byte) {
+func (s *state) setCommittedSeals(seals []*messages.CommittedSeal) {
 	s.Lock()
 	defer s.Unlock()
 

--- a/messages/helpers.go
+++ b/messages/helpers.go
@@ -2,12 +2,18 @@ package messages
 
 import (
 	"bytes"
+
 	"github.com/0xPolygon/go-ibft/messages/proto"
 )
 
+type CommittedSeal struct {
+	Signer    []byte
+	Signature []byte
+}
+
 // ExtractCommittedSeals extracts the committed seals from the passed in messages
-func ExtractCommittedSeals(commitMessages []*proto.Message) [][]byte {
-	committedSeals := make([][]byte, 0)
+func ExtractCommittedSeals(commitMessages []*proto.Message) []*CommittedSeal {
+	committedSeals := make([]*CommittedSeal, 0)
 
 	for _, commitMessage := range commitMessages {
 		if commitMessage.Type != proto.MessageType_COMMIT {
@@ -21,10 +27,13 @@ func ExtractCommittedSeals(commitMessages []*proto.Message) [][]byte {
 }
 
 // ExtractCommittedSeal extracts the committed seal from the passed in message
-func ExtractCommittedSeal(commitMessage *proto.Message) []byte {
+func ExtractCommittedSeal(commitMessage *proto.Message) *CommittedSeal {
 	commitData, _ := commitMessage.Payload.(*proto.Message_CommitData)
 
-	return commitData.CommitData.CommittedSeal
+	return &CommittedSeal{
+		Signer:    commitMessage.From,
+		Signature: commitData.CommitData.CommittedSeal,
+	}
 }
 
 // ExtractCommitHash extracts the commit proposal hash from the passed in message

--- a/messages/helpers_test.go
+++ b/messages/helpers_test.go
@@ -1,14 +1,16 @@
 package messages
 
 import (
+	"testing"
+
 	"github.com/0xPolygon/go-ibft/messages/proto"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestMessages_ExtractCommittedSeals(t *testing.T) {
 	t.Parallel()
 
+	signer := []byte("signer")
 	committedSeal := []byte("committed seal")
 
 	commitMessage := &proto.Message{
@@ -18,6 +20,7 @@ func TestMessages_ExtractCommittedSeals(t *testing.T) {
 				CommittedSeal: committedSeal,
 			},
 		},
+		From: signer,
 	}
 	invalidMessage := &proto.Message{
 		Type: proto.MessageType_PREPARE,
@@ -32,7 +35,12 @@ func TestMessages_ExtractCommittedSeals(t *testing.T) {
 		t.Fatalf("Seals not extracted")
 	}
 
-	assert.Equal(t, committedSeal, seals[0])
+	expected := &CommittedSeal{
+		Signer:    signer,
+		Signature: committedSeal,
+	}
+
+	assert.Equal(t, expected, seals[0])
 }
 
 func TestMessages_ExtractCommitHash(t *testing.T) {


### PR DESCRIPTION
# Description

For BLS feature in Polygon Edge (https://github.com/0xPolygon/polygon-edge/pull/574 and https://github.com/0xPolygon/polygon-edge/pull/649), address of signer is required in order to verify CommittedSeal and create aggregated CommittedSeals.

This PR changes the type of committedSeal in `IsValidCommittedSeal` and `InsertBlock`

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have added sufficient documentation in code

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
