### PR TITLE
Introduce property based tests with Rapid + bump go version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
 
       - name: Checkout code
         uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
 
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ dist/
 .DS_Store
 .vscode
 .idea
+
+# Rapid Framework Leftovers
+testdata/

--- a/core/consensus_test.go
+++ b/core/consensus_test.go
@@ -109,14 +109,15 @@ func maxFaulty(nodeCount uint64) uint64 {
 	return (nodeCount - 1) / 3
 }
 
-// quorumOptimal returns the minimum number of
+// quorum returns the minimum number of
 // required nodes to reach quorum
-func quorumOptimal(numNodes uint64) uint64 {
-	if maxFaulty(numNodes) == 0 {
+func quorum(numNodes uint64) uint64 {
+	switch maxFaulty(numNodes) {
+	case 0:
 		return numNodes
+	default:
+		return uint64(math.Ceil(2 * float64(numNodes) / 3))
 	}
-
-	return uint64(math.Ceil(2 * float64(numNodes) / 3))
 }
 
 // TestConsensus_ValidFlow tests the following scenario:
@@ -310,7 +311,7 @@ func TestConsensus_InvalidBlock(t *testing.T) {
 	commonBackendCallback := func(backend *mockBackend, nodeIndex int) {
 		// Make sure the quorum function is Quorum optimal
 		backend.quorumFn = func(_ uint64) uint64 {
-			return quorumOptimal(numNodes)
+			return quorum(numNodes)
 		}
 
 		// Make sure the allowed faulty nodes function is accurate

--- a/core/consensus_test.go
+++ b/core/consensus_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // generateNodeAddresses generates dummy node addresses
-func generateNodeAddresses(count int) [][]byte {
+func generateNodeAddresses(count uint64) [][]byte {
 	addresses := make([][]byte, count)
 
 	for index := range addresses {
@@ -117,7 +117,7 @@ func TestConsensus_ValidFlow(t *testing.T) {
 	proposal := []byte("proposal")
 	proposalHash := []byte("proposal hash")
 	committedSeal := []byte("seal")
-	numNodes := 4
+	numNodes := uint64(4)
 	nodes := generateNodeAddresses(numNodes)
 	insertedBlocks := make([][]byte, numNodes)
 
@@ -134,7 +134,7 @@ func TestConsensus_ValidFlow(t *testing.T) {
 	commonBackendCallback := func(backend *mockBackend, nodeIndex int) {
 		// Make sure the quorum function requires all nodes
 		backend.quorumFn = func(_ uint64) uint64 {
-			return uint64(numNodes)
+			return numNodes
 		}
 
 		// Make sure the node ID is properly relayed
@@ -277,7 +277,7 @@ func TestConsensus_InvalidBlock(t *testing.T) {
 		[]byte("proposal hash 2"), // for proposal 2
 	}
 	committedSeal := []byte("seal")
-	numNodes := 4
+	numNodes := uint64(4)
 	nodes := generateNodeAddresses(numNodes)
 	insertedBlocks := make([][]byte, numNodes)
 
@@ -289,13 +289,13 @@ func TestConsensus_InvalidBlock(t *testing.T) {
 		}
 	}
 
-	maxFaulty := func(nodeCount int) uint64 {
-		return uint64((nodeCount - 1) / 3)
+	maxFaulty := func(nodeCount uint64) uint64 {
+		return (nodeCount - 1) / 3
 	}
 
-	quorumOptimal := func(numNodes int) uint64 {
+	quorumOptimal := func(numNodes uint64) uint64 {
 		if maxFaulty(numNodes) == 0 {
-			return uint64(numNodes)
+			return numNodes
 		}
 
 		return uint64(math.Ceil(2 * float64(numNodes) / 3))

--- a/core/ibft.go
+++ b/core/ibft.go
@@ -143,9 +143,9 @@ func (i *IBFT) startRoundTimer(ctx context.Context, round uint64) {
 	}
 }
 
-//	signalRoundExpired notifies the sequence routine (RunSequence) that it
-//	should move to a new round. The quit channel is used to abort this call
-//	if another routine has already signaled a round change request.
+// signalRoundExpired notifies the sequence routine (RunSequence) that it
+// should move to a new round. The quit channel is used to abort this call
+// if another routine has already signaled a round change request.
 func (i *IBFT) signalRoundExpired(ctx context.Context) {
 	select {
 	case i.roundExpired <- struct{}{}:
@@ -153,8 +153,8 @@ func (i *IBFT) signalRoundExpired(ctx context.Context) {
 	}
 }
 
-//	signalRoundDone notifies the sequence routine (RunSequence) that the
-//	consensus sequence is finished
+// signalRoundDone notifies the sequence routine (RunSequence) that the
+// consensus sequence is finished
 func (i *IBFT) signalRoundDone(ctx context.Context) {
 	select {
 	case i.roundDone <- struct{}{}:
@@ -501,7 +501,7 @@ func (i *IBFT) proposalMatchesCertificate(
 	return true
 }
 
-//	runStates is the main loop which performs state transitions
+// runStates is the main loop which performs state transitions
 func (i *IBFT) runStates(ctx context.Context) {
 	var timeout error
 
@@ -713,8 +713,8 @@ func (i *IBFT) validateProposal(msg *proto.Message, view *proto.View) bool {
 	return bytes.Equal(expectedHash, proposalHash)
 }
 
-//	handlePrePrepare parses the received proposal and performs
-//	a transition to PREPARE state, if the proposal is valid
+// handlePrePrepare parses the received proposal and performs
+// a transition to PREPARE state, if the proposal is valid
 func (i *IBFT) handlePrePrepare(view *proto.View) *proto.Message {
 	isValidPrePrepare := func(message *proto.Message) bool {
 		if view.Round == 0 {
@@ -780,8 +780,8 @@ func (i *IBFT) runPrepare(ctx context.Context) error {
 	}
 }
 
-//	handlePrepare parses available prepare messages and performs
-//	a transition to COMMIT state, if quorum was reached
+// handlePrepare parses available prepare messages and performs
+// a transition to COMMIT state, if quorum was reached
 func (i *IBFT) handlePrepare(view *proto.View, quorum uint64) bool {
 	isValidPrepare := func(message *proto.Message) bool {
 		// Verify that the proposal hash is valid
@@ -860,8 +860,8 @@ func (i *IBFT) runCommit(ctx context.Context) error {
 	}
 }
 
-//	handleCommit parses available commit messages and performs
-//	a transition to FIN state, if quorum was reached
+// handleCommit parses available commit messages and performs
+// a transition to FIN state, if quorum was reached
 func (i *IBFT) handleCommit(view *proto.View, quorum uint64) bool {
 	isValidCommit := func(message *proto.Message) bool {
 		var (
@@ -1028,7 +1028,7 @@ func (i *IBFT) isAcceptableMessage(message *proto.Message) bool {
 	return message.View.Round >= i.state.getRound()
 }
 
-//	ExtendRoundTimeout extends each round's timer by the specified amount.
+// ExtendRoundTimeout extends each round's timer by the specified amount.
 func (i *IBFT) ExtendRoundTimeout(amount time.Duration) {
 	i.additionalTimeout = amount
 }

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -300,7 +300,7 @@ func newMockCluster(
 	}
 
 	nodes := make([]*IBFT, numNodes)
-	nodeCtxs := make([]*mockNodeContext, numNodes)
+	nodeCtxs := make([]mockNodeContext, numNodes)
 
 	for index := 0; index < int(numNodes); index++ {
 		var (
@@ -333,7 +333,7 @@ func newMockCluster(
 
 		// Instantiate context for the nodes
 		ctx, cancelFn := context.WithCancel(context.Background())
-		nodeCtxs[index] = &mockNodeContext{
+		nodeCtxs[index] = mockNodeContext{
 			ctx:      ctx,
 			cancelFn: cancelFn,
 		}
@@ -376,8 +376,8 @@ func (wg *mockNodeWg) resetDone() {
 
 // mockCluster represents a mock IBFT cluster
 type mockCluster struct {
-	nodes []*IBFT            // references to the nodes in the cluster
-	ctxs  []*mockNodeContext // context handlers for the nodes in the cluster
+	nodes []*IBFT           // references to the nodes in the cluster
+	ctxs  []mockNodeContext // context handlers for the nodes in the cluster
 
 	wg mockNodeWg
 }

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -288,7 +288,7 @@ type transportConfigCallback func(*mockTransport)
 
 // newMockCluster creates a new IBFT cluster
 func newMockCluster(
-	numNodes int,
+	numNodes uint64,
 	backendCallbackMap map[int]backendConfigCallback,
 	loggerCallbackMap map[int]loggerConfigCallback,
 	transportCallbackMap map[int]transportConfigCallback,
@@ -301,7 +301,7 @@ func newMockCluster(
 	quitChannels := make([]chan struct{}, numNodes)
 	messageHandlersQuit := make([]chan struct{}, numNodes)
 
-	for index := 0; index < numNodes; index++ {
+	for index := 0; index < int(numNodes); index++ {
 		var (
 			logger    = &mockLogger{}
 			transport = &mockTransport{}
@@ -361,6 +361,17 @@ func (m *mockCluster) runSequence(height uint64) {
 			// Start the main run loop for the node
 			node.RunSequence(context.Background(), height)
 		}(node, height)
+	}
+}
+
+// runSequenceUntilHeight runs multiple sequence iterations until the desired height is reached
+func (m *mockCluster) runSequenceUntilHeight(desiredHeight uint64) {
+	for height := uint64(0); height < desiredHeight; height++ {
+		// Start the main run loops
+		m.runSequence(height)
+
+		// Wait until the main run loops finish
+		m.stop()
 	}
 }
 

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -2,7 +2,9 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/0xPolygon/go-ibft/messages"
@@ -298,8 +300,7 @@ func newMockCluster(
 	}
 
 	nodes := make([]*IBFT, numNodes)
-	quitChannels := make([]chan struct{}, numNodes)
-	messageHandlersQuit := make([]chan struct{}, numNodes)
+	nodeCtxs := make([]*mockNodeContext, numNodes)
 
 	for index := 0; index < int(numNodes); index++ {
 		var (
@@ -328,59 +329,119 @@ func newMockCluster(
 		}
 
 		// Create a new instance of the IBFT node
-		i := NewIBFT(logger, backend, transport)
+		nodes[index] = NewIBFT(logger, backend, transport)
 
-		// Instantiate quit channels for node routines
-		quitChannels[index] = make(chan struct{})
-		messageHandlersQuit[index] = make(chan struct{})
-
-		nodes[index] = i
+		// Instantiate context for the nodes
+		ctx, cancelFn := context.WithCancel(context.Background())
+		nodeCtxs[index] = &mockNodeContext{
+			ctx:      ctx,
+			cancelFn: cancelFn,
+		}
 	}
 
 	return &mockCluster{
 		nodes: nodes,
+		ctxs:  nodeCtxs,
 	}
+}
+
+// mockNodeContext keeps track of the node runtime context
+type mockNodeContext struct {
+	ctx      context.Context
+	cancelFn context.CancelFunc
+}
+
+// mockNodeWg is the WaitGroup wrapper for the cluster nodes
+type mockNodeWg struct {
+	sync.WaitGroup
+	count int64
+}
+
+func (wg *mockNodeWg) Add(delta int) {
+	wg.WaitGroup.Add(delta)
+}
+
+func (wg *mockNodeWg) Done() {
+	wg.WaitGroup.Done()
+	atomic.AddInt64(&wg.count, 1)
+}
+
+func (wg *mockNodeWg) getDone() int64 {
+	return atomic.LoadInt64(&wg.count)
+}
+
+func (wg *mockNodeWg) resetDone() {
+	wg.count = 0
 }
 
 // mockCluster represents a mock IBFT cluster
 type mockCluster struct {
-	nodes []*IBFT // references to the nodes in the cluster
+	nodes []*IBFT            // references to the nodes in the cluster
+	ctxs  []*mockNodeContext // context handlers for the nodes in the cluster
 
-	wg sync.WaitGroup
+	wg mockNodeWg
 }
 
 func (m *mockCluster) runSequence(height uint64) {
-	for _, node := range m.nodes {
+	m.wg.resetDone()
+
+	for nodeIndex, node := range m.nodes {
 		m.wg.Add(1)
 
-		go func(node *IBFT, height uint64) {
+		go func(
+			ctx context.Context,
+			node *IBFT,
+			height uint64,
+		) {
 			defer func() {
 				m.wg.Done()
 			}()
 
 			// Start the main run loop for the node
-			node.RunSequence(context.Background(), height)
-		}(node, height)
+			node.RunSequence(ctx, height)
+		}(m.ctxs[nodeIndex].ctx, node, height)
 	}
 }
 
-// runSequenceUntilHeight runs multiple sequence iterations until the desired height is reached
-func (m *mockCluster) runSequenceUntilHeight(desiredHeight uint64) {
-	for height := uint64(0); height < desiredHeight; height++ {
-		// Start the main run loops
-		m.runSequence(height)
-
-		// Wait until the main run loops finish
-		m.stop()
-	}
-}
-
-// stop sends a quit signal to all nodes
-// in the cluster
-func (m *mockCluster) stop() {
+// awaitCompletion waits for completion of all
+// nodes in the cluster
+func (m *mockCluster) awaitCompletion() {
 	// Wait for all main run loops to signalize
 	// that they're finished
 	m.wg.Wait()
+}
+
+// forceShutdown sends a stop signal to all running nodes
+// in the cluster, and awaits their completion
+func (m *mockCluster) forceShutdown() {
+	// Send a stop signal to all the nodes
+	for _, ctx := range m.ctxs {
+		ctx.cancelFn()
+	}
+
+	// Wait for all the nodes to finish
+	m.awaitCompletion()
+}
+
+// awaitNCompletions awaits completion of the current sequence
+// for N nodes in the cluster
+func (m *mockCluster) awaitNCompletions(
+	ctx context.Context,
+	count int64,
+) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf(
+				"await exceeded timeout for %d nodes",
+				count,
+			)
+		default:
+			if m.wg.getDone() >= count {
+				return nil
+			}
+		}
+	}
 }
 
 // pushMessage imitates a message passing service,

--- a/core/rapid_test.go
+++ b/core/rapid_test.go
@@ -201,11 +201,11 @@ func TestProperty_MajorityHonestNodes(t *testing.T) {
 		gen := rapid.SampledFrom(nodes)
 		byzantineNodes := make(map[string]struct{})
 		for i := 0; i < int(numByzantineNodes); i++ {
-			byzantineNodes[fmt.Sprintf("%s", gen.Example(i))] = struct{}{}
+			byzantineNodes[string(gen.Example(i))] = struct{}{}
 		}
 
 		isByzantineNode := func(from []byte) bool {
-			_, exists := byzantineNodes[fmt.Sprintf("%s", from)]
+			_, exists := byzantineNodes[string(from)]
 
 			return exists
 		}

--- a/core/rapid_test.go
+++ b/core/rapid_test.go
@@ -267,7 +267,7 @@ func TestProperty_MajorityHonestNodes(t *testing.T) {
 		commonBackendCallback := func(backend *mockBackend, nodeIndex int) {
 			// Make sure the quorum function is Quorum optimal
 			backend.quorumFn = func(_ uint64) uint64 {
-				return quorumOptimal(numNodes)
+				return quorum(numNodes)
 			}
 
 			// Make sure the allowed faulty nodes function is accurate
@@ -382,7 +382,7 @@ func TestProperty_MajorityHonestNodes(t *testing.T) {
 
 			// Wait until Quorum nodes finish their run loop
 			ctx, cancelFn := context.WithTimeout(context.Background(), time.Second*5)
-			if err := cluster.awaitNCompletions(ctx, int64(quorumOptimal(numNodes))); err != nil {
+			if err := cluster.awaitNCompletions(ctx, int64(quorum(numNodes))); err != nil {
 				t.Fatalf(
 					fmt.Sprintf(
 						"unable to wait for nodes to complete, %v",

--- a/core/rapid_test.go
+++ b/core/rapid_test.go
@@ -149,13 +149,13 @@ func TestProperty_AllHonestNodes(t *testing.T) {
 		// Run the sequence up until a certain height
 		cluster.runSequenceUntilHeight(desiredHeight)
 
-		// Make sure that the inserted block is valid for each height
-		for _, blockMap := range insertedBlocks {
-			// Make sure the node has the adequate number of inserted blocks
-			assert.Len(t, blockMap, int(desiredHeight))
+		// Make sure that the inserted proposal is valid for each height
+		for _, proposalMap := range insertedBlocks {
+			// Make sure the node has the adequate number of inserted proposals
+			assert.Len(t, proposalMap, int(desiredHeight))
 
-			for _, block := range blockMap {
-				assert.True(t, bytes.Equal(proposal, block))
+			for _, insertedProposal := range proposalMap {
+				assert.True(t, bytes.Equal(proposal, insertedProposal))
 			}
 		}
 	})

--- a/core/rapid_test.go
+++ b/core/rapid_test.go
@@ -2,7 +2,10 @@ package core
 
 import (
 	"bytes"
+	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/0xPolygon/go-ibft/messages"
 	"github.com/0xPolygon/go-ibft/messages/proto"
@@ -147,13 +150,220 @@ func TestProperty_AllHonestNodes(t *testing.T) {
 		}
 
 		// Run the sequence up until a certain height
-		cluster.runSequenceUntilHeight(desiredHeight)
+		for height := uint64(0); height < desiredHeight; height++ {
+			// Start the main run loops
+			cluster.runSequence(height)
+
+			// Wait until the main run loops finish
+			cluster.awaitCompletion()
+		}
 
 		// Make sure that the inserted proposal is valid for each height
 		for _, proposalMap := range insertedBlocks {
 			// Make sure the node has the adequate number of inserted proposals
 			assert.Len(t, proposalMap, int(desiredHeight))
 
+			for _, insertedProposal := range proposalMap {
+				assert.True(t, bytes.Equal(proposal, insertedProposal))
+			}
+		}
+	})
+}
+
+// TestProperty_MajorityHonestNodes is a property-based test
+// that assures the cluster can reach consensus on any
+// arbitrary number of valid nodes and byzantine nodes
+func TestProperty_MajorityHonestNodes(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(t *rapid.T) {
+		var multicastFn func(message *proto.Message)
+
+		var (
+			proposal      = []byte("proposal")
+			proposalHash  = []byte("proposal hash")
+			committedSeal = []byte("seal")
+
+			numNodes          = rapid.Uint64Range(4, 30).Draw(t, "number of cluster nodes")
+			numByzantineNodes = rapid.Uint64Range(1, maxFaulty(numNodes)).Draw(t, "number of byzantine nodes")
+			desiredHeight     = rapid.Uint64Range(1, 5).Draw(t, "minimum height to be reached")
+
+			nodes            = generateNodeAddresses(numNodes)
+			insertedBlocks   = make([]map[uint64][]byte, numNodes)
+			currentProposals = make([]uint64, numNodes)
+		)
+		// Initialize the block insertion map, used for lookups
+		for i := uint64(0); i < numNodes; i++ {
+			insertedBlocks[i] = make(map[uint64][]byte)
+		}
+
+		// Initialize the byzantine nodes
+		gen := rapid.SampledFrom(nodes)
+		byzantineNodes := make(map[string]struct{})
+		for i := 0; i < int(numByzantineNodes); i++ {
+			byzantineNodes[fmt.Sprintf("%s", gen.Example(i))] = struct{}{}
+		}
+
+		isByzantineNode := func(from []byte) bool {
+			_, exists := byzantineNodes[fmt.Sprintf("%s", from)]
+
+			return exists
+		}
+
+		// commonTransportCallback is the common method modification
+		// required for Transport, for all nodes
+		commonTransportCallback := func(transport *mockTransport) {
+			transport.multicastFn = func(message *proto.Message) {
+				if isByzantineNode(message.From) {
+					// If the node is byzantine, mock
+					// not sending out the message
+					return
+				}
+
+				multicastFn(message)
+			}
+		}
+
+		// commonBackendCallback is the common method modification required
+		// for the Backend, for all nodes
+		commonBackendCallback := func(backend *mockBackend, nodeIndex int) {
+			// Make sure the quorum function is Quorum optimal
+			backend.quorumFn = func(_ uint64) uint64 {
+				return quorumOptimal(numNodes)
+			}
+
+			// Make sure the allowed faulty nodes function is accurate
+			backend.maximumFaultyNodesFn = func() uint64 {
+				return maxFaulty(numNodes)
+			}
+
+			// Make sure the node ID is properly relayed
+			backend.idFn = func() []byte {
+				return nodes[nodeIndex]
+			}
+
+			// Make sure the only proposer is picked using Round Robin
+			backend.isProposerFn = func(from []byte, height uint64, round uint64) bool {
+				return bytes.Equal(
+					from,
+					nodes[int(height+round)%len(nodes)],
+				)
+			}
+
+			// Make sure the proposal is valid if it matches what node 0 proposed
+			backend.isValidBlockFn = func(newProposal []byte) bool {
+				return bytes.Equal(newProposal, proposal)
+			}
+
+			// Make sure the proposal hash matches
+			backend.isValidProposalHashFn = func(p []byte, ph []byte) bool {
+				return bytes.Equal(p, proposal) && bytes.Equal(ph, proposalHash)
+			}
+
+			// Make sure the preprepare message is built correctly
+			backend.buildPrePrepareMessageFn = func(
+				proposal []byte,
+				certificate *proto.RoundChangeCertificate,
+				view *proto.View,
+			) *proto.Message {
+				return buildBasicPreprepareMessage(
+					proposal,
+					proposalHash,
+					certificate,
+					nodes[nodeIndex],
+					view)
+			}
+
+			// Make sure the prepare message is built correctly
+			backend.buildPrepareMessageFn = func(proposal []byte, view *proto.View) *proto.Message {
+				return buildBasicPrepareMessage(proposalHash, nodes[nodeIndex], view)
+			}
+
+			// Make sure the commit message is built correctly
+			backend.buildCommitMessageFn = func(proposal []byte, view *proto.View) *proto.Message {
+				return buildBasicCommitMessage(proposalHash, committedSeal, nodes[nodeIndex], view)
+			}
+
+			// Make sure the round change message is built correctly
+			backend.buildRoundChangeMessageFn = func(
+				proposal []byte,
+				certificate *proto.PreparedCertificate,
+				view *proto.View,
+			) *proto.Message {
+				return buildBasicRoundChangeMessage(proposal, certificate, view, nodes[nodeIndex])
+			}
+
+			// Make sure the inserted proposal is noted
+			backend.insertBlockFn = func(proposal []byte, _ []*messages.CommittedSeal) {
+				if isByzantineNode(nodes[nodeIndex]) {
+					return
+				}
+
+				insertedBlocks[nodeIndex][currentProposals[nodeIndex]] = proposal
+				currentProposals[nodeIndex]++
+			}
+
+			// Make sure the proposal can be built
+			backend.buildProposalFn = func(u uint64) []byte {
+				return proposal
+			}
+		}
+
+		// Initialize the backend and transport callbacks for
+		// each node in the arbitrary cluster
+		backendCallbackMap := make(map[int]backendConfigCallback)
+		transportCallbackMap := make(map[int]transportConfigCallback)
+
+		for i := 0; i < int(numNodes); i++ {
+			i := i
+			backendCallbackMap[i] = func(backend *mockBackend) {
+				commonBackendCallback(backend, i)
+			}
+
+			transportCallbackMap[i] = commonTransportCallback
+		}
+
+		// Create the mock cluster
+		cluster := newMockCluster(
+			numNodes,
+			backendCallbackMap,
+			nil,
+			transportCallbackMap,
+		)
+
+		// Set a small timeout, because of situations
+		// where the byzantine node is the proposer
+		cluster.setBaseTimeout(time.Second * 2)
+
+		// Set the multicast callback to relay the message
+		// to the entire cluster
+		multicastFn = func(message *proto.Message) {
+			cluster.pushMessage(message)
+		}
+
+		// Run the sequence up until a certain height
+		for height := uint64(0); height < desiredHeight; height++ {
+			// Start the main run loops
+			cluster.runSequence(height)
+
+			// Wait until Quorum nodes finish their run loop
+			ctx, cancelFn := context.WithTimeout(context.Background(), time.Second*5)
+			if err := cluster.awaitNCompletions(ctx, int64(quorumOptimal(numNodes))); err != nil {
+				t.Fatalf(
+					fmt.Sprintf(
+						"unable to wait for nodes to complete, %v",
+						err,
+					),
+				)
+			}
+
+			// Shutdown the remaining nodes that might be hanging
+			cluster.forceShutdown()
+			cancelFn()
+		}
+
+		// Make sure that the inserted proposal is valid for each height
+		for _, proposalMap := range insertedBlocks {
 			for _, insertedProposal := range proposalMap {
 				assert.True(t, bytes.Equal(proposal, insertedProposal))
 			}

--- a/core/rapid_test.go
+++ b/core/rapid_test.go
@@ -1,0 +1,162 @@
+package core
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/0xPolygon/go-ibft/messages"
+	"github.com/0xPolygon/go-ibft/messages/proto"
+	"github.com/stretchr/testify/assert"
+	"pgregory.net/rapid"
+)
+
+// TestProperty_AllHonestNodes is a property-based test
+// that assures the cluster can reach consensus on any
+// arbitrary number of valid nodes
+func TestProperty_AllHonestNodes(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(t *rapid.T) {
+		var multicastFn func(message *proto.Message)
+
+		var (
+			proposal      = []byte("proposal")
+			proposalHash  = []byte("proposal hash")
+			committedSeal = []byte("seal")
+
+			numNodes      = rapid.Uint64Range(4, 30).Draw(t, "number of cluster nodes")
+			desiredHeight = rapid.Uint64Range(10, 20).Draw(t, "minimum height to be reached")
+
+			nodes            = generateNodeAddresses(numNodes)
+			insertedBlocks   = make([]map[uint64][]byte, numNodes)
+			currentProposals = make([]uint64, numNodes)
+		)
+
+		// Initialize the block insertion map, used for lookups
+		for i := uint64(0); i < numNodes; i++ {
+			insertedBlocks[i] = make(map[uint64][]byte)
+		}
+
+		// commonTransportCallback is the common method modification
+		// required for Transport, for all nodes
+		commonTransportCallback := func(transport *mockTransport) {
+			transport.multicastFn = func(message *proto.Message) {
+				multicastFn(message)
+			}
+		}
+
+		// commonBackendCallback is the common method modification required
+		// for the Backend, for all nodes
+		commonBackendCallback := func(backend *mockBackend, nodeIndex int) {
+			// Make sure the quorum function requires all nodes
+			backend.quorumFn = func(_ uint64) uint64 {
+				return numNodes
+			}
+
+			// Make sure the node ID is properly relayed
+			backend.idFn = func() []byte {
+				return nodes[nodeIndex]
+			}
+
+			// Make sure the only proposer is picked using Round Robin
+			backend.isProposerFn = func(from []byte, height uint64, _ uint64) bool {
+				return bytes.Equal(from, nodes[height%numNodes])
+			}
+
+			// Make sure the proposal is valid if it matches what node 0 proposed
+			backend.isValidBlockFn = func(newProposal []byte) bool {
+				return bytes.Equal(newProposal, proposal)
+			}
+
+			// Make sure the proposal hash matches
+			backend.isValidProposalHashFn = func(p []byte, ph []byte) bool {
+				return bytes.Equal(p, proposal) && bytes.Equal(ph, proposalHash)
+			}
+
+			// Make sure the preprepare message is built correctly
+			backend.buildPrePrepareMessageFn = func(
+				proposal []byte,
+				certificate *proto.RoundChangeCertificate,
+				view *proto.View,
+			) *proto.Message {
+				return buildBasicPreprepareMessage(
+					proposal,
+					proposalHash,
+					certificate,
+					nodes[nodeIndex],
+					view)
+			}
+
+			// Make sure the prepare message is built correctly
+			backend.buildPrepareMessageFn = func(proposal []byte, view *proto.View) *proto.Message {
+				return buildBasicPrepareMessage(proposalHash, nodes[nodeIndex], view)
+			}
+
+			// Make sure the commit message is built correctly
+			backend.buildCommitMessageFn = func(proposal []byte, view *proto.View) *proto.Message {
+				return buildBasicCommitMessage(proposalHash, committedSeal, nodes[nodeIndex], view)
+			}
+
+			// Make sure the round change message is built correctly
+			backend.buildRoundChangeMessageFn = func(
+				proposal []byte,
+				certificate *proto.PreparedCertificate,
+				view *proto.View,
+			) *proto.Message {
+				return buildBasicRoundChangeMessage(proposal, certificate, view, nodes[nodeIndex])
+			}
+
+			// Make sure the inserted proposal is noted
+			backend.insertBlockFn = func(proposal []byte, _ []*messages.CommittedSeal) {
+				insertedBlocks[nodeIndex][currentProposals[nodeIndex]] = proposal
+				currentProposals[nodeIndex]++
+			}
+
+			// Make sure the proposal can be built
+			backend.buildProposalFn = func(u uint64) []byte {
+				return proposal
+			}
+		}
+
+		// Initialize the backend and transport callbacks for
+		// each node in the arbitrary cluster
+		backendCallbackMap := make(map[int]backendConfigCallback)
+		transportCallbackMap := make(map[int]transportConfigCallback)
+
+		for i := 0; i < int(numNodes); i++ {
+			i := i
+			backendCallbackMap[i] = func(backend *mockBackend) {
+				commonBackendCallback(backend, i)
+			}
+
+			transportCallbackMap[i] = commonTransportCallback
+		}
+
+		// Create the mock cluster
+		cluster := newMockCluster(
+			numNodes,
+			backendCallbackMap,
+			nil,
+			transportCallbackMap,
+		)
+
+		// Set the multicast callback to relay the message
+		// to the entire cluster
+		multicastFn = func(message *proto.Message) {
+			cluster.pushMessage(message)
+		}
+
+		// Run the sequence up until a certain height
+		cluster.runSequenceUntilHeight(desiredHeight)
+
+		// Make sure that the inserted block is valid for each height
+		for _, blockMap := range insertedBlocks {
+			// Make sure the node has the adequate number of inserted blocks
+			assert.Len(t, blockMap, int(desiredHeight))
+
+			for _, block := range blockMap {
+				assert.True(t, bytes.Equal(proposal, block))
+			}
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/0xPolygon/go-ibft
 
-go 1.17
+go 1.18
 
 require (
 	github.com/google/uuid v1.3.0
@@ -12,4 +12,5 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	pgregory.net/rapid v0.5.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -23,3 +23,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+pgregory.net/rapid v0.5.3 h1:163N50IHFqr1phZens4FQOdPgfJscR7a562mjQqeo4M=
+pgregory.net/rapid v0.5.3/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=


### PR DESCRIPTION
# Description

This PR introduces the [rapid](https://github.com/flyingmutant/rapid) property-based testing framework, and introduces 2 new property-based tests.

Additionally, the minimum `go` version has been bumped to `go 1.18` to accommodate for rapid.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

The minimum `go` version is changed from `1.17 => 1.18`

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [x] I have added sufficient documentation in code
