### PR TITLE
Expand `BuildProposal` with current round information

### DIFF
--- a/core/backend.go
+++ b/core/backend.go
@@ -53,7 +53,7 @@ type Backend interface {
 	Verifier
 
 	// BuildProposal builds a new block proposal
-	BuildProposal(blockNumber uint64) []byte
+	BuildProposal(view *proto.View) []byte
 
 	// InsertBlock inserts a proposal with the specified committed seals
 	InsertBlock(proposal []byte, committedSeals []*messages.CommittedSeal)

--- a/core/consensus_test.go
+++ b/core/consensus_test.go
@@ -222,7 +222,7 @@ func TestConsensus_ValidFlow(t *testing.T) {
 
 				// Set the proposal creation method for node 0, since
 				// they are the proposer
-				backend.buildProposalFn = func(u uint64) []byte {
+				backend.buildProposalFn = func(_ *proto.View) []byte {
 					return proposal
 				}
 			},
@@ -393,14 +393,14 @@ func TestConsensus_InvalidBlock(t *testing.T) {
 			0: func(backend *mockBackend) {
 				commonBackendCallback(backend, 0)
 
-				backend.buildProposalFn = func(_ uint64) []byte {
+				backend.buildProposalFn = func(_ *proto.View) []byte {
 					return proposals[0]
 				}
 			},
 			1: func(backend *mockBackend) {
 				commonBackendCallback(backend, 1)
 
-				backend.buildProposalFn = func(_ uint64) []byte {
+				backend.buildProposalFn = func(_ *proto.View) []byte {
 					return proposals[1]
 				}
 			},

--- a/core/helpers_test.go
+++ b/core/helpers_test.go
@@ -22,7 +22,7 @@ func isValidProposal(newProposal []byte) bool {
 	return bytes.Equal(newProposal, validProposal)
 }
 
-func buildValidProposal(_ uint64) []byte {
+func buildValidProposal(_ *proto.View) []byte {
 	return validProposal
 }
 

--- a/core/ibft.go
+++ b/core/ibft.go
@@ -929,7 +929,7 @@ func (i *IBFT) buildProposal(ctx context.Context, view *proto.View) *proto.Messa
 	)
 
 	if round == 0 {
-		proposal := i.backend.BuildProposal(height)
+		proposal := i.backend.BuildProposal(view)
 
 		return i.backend.BuildPrePrepareMessage(
 			proposal,
@@ -964,7 +964,7 @@ func (i *IBFT) buildProposal(ctx context.Context, view *proto.View) *proto.Messa
 
 	if previousProposal == nil {
 		//	build new proposal
-		proposal := i.backend.BuildProposal(height)
+		proposal := i.backend.BuildProposal(view)
 
 		return i.backend.BuildPrePrepareMessage(
 			proposal,

--- a/core/ibft_test.go
+++ b/core/ibft_test.go
@@ -235,7 +235,7 @@ func TestRunNewRound_Proposer(t *testing.T) {
 					isProposerFn: func(_ []byte, _ uint64, _ uint64) bool {
 						return true
 					},
-					buildProposalFn: func(_ uint64) []byte {
+					buildProposalFn: func(_ *proto.View) []byte {
 						return newProposal
 					},
 					buildPrePrepareMessageFn: func(
@@ -322,7 +322,7 @@ func TestRunNewRound_Proposer(t *testing.T) {
 					quorumFn: func(_ uint64) uint64 {
 						return quorum
 					},
-					buildProposalFn: func(_ uint64) []byte {
+					buildProposalFn: func(_ *proto.View) []byte {
 						return proposal
 					},
 					buildPrepareMessageFn: func(_ []byte, view *proto.View) *proto.Message {
@@ -478,7 +478,7 @@ func TestRunNewRound_Proposer(t *testing.T) {
 					quorumFn: func(_ uint64) uint64 {
 						return quorum
 					},
-					buildProposalFn: func(_ uint64) []byte {
+					buildProposalFn: func(_ *proto.View) []byte {
 						return proposal
 					},
 					buildPrepareMessageFn: func(_ []byte, view *proto.View) *proto.Message {

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -15,7 +15,7 @@ import (
 type isValidBlockDelegate func([]byte) bool
 type isValidSenderDelegate func(*proto.Message) bool
 type isProposerDelegate func([]byte, uint64, uint64) bool
-type buildProposalDelegate func(uint64) []byte
+type buildProposalDelegate func(*proto.View) []byte
 type isValidProposalHashDelegate func([]byte, []byte) bool
 type isValidCommittedSealDelegate func([]byte, *messages.CommittedSeal) bool
 
@@ -102,9 +102,9 @@ func (m mockBackend) IsProposer(id []byte, sequence, round uint64) bool {
 	return false
 }
 
-func (m mockBackend) BuildProposal(blockNumber uint64) []byte {
+func (m mockBackend) BuildProposal(view *proto.View) []byte {
 	if m.buildProposalFn != nil {
-		return m.buildProposalFn(blockNumber)
+		return m.buildProposalFn(view)
 	}
 
 	return nil

--- a/core/rapid_test.go
+++ b/core/rapid_test.go
@@ -146,7 +146,7 @@ func TestProperty_AllHonestNodes(t *testing.T) {
 			}
 
 			// Make sure the proposal can be built
-			backend.buildProposalFn = func(u uint64) []byte {
+			backend.buildProposalFn = func(_ *proto.View) []byte {
 				return proposal
 			}
 		}
@@ -339,7 +339,7 @@ func TestProperty_MajorityHonestNodes(t *testing.T) {
 			}
 
 			// Make sure the proposal can be built
-			backend.buildProposalFn = func(u uint64) []byte {
+			backend.buildProposalFn = func(_ *proto.View) []byte {
 				return proposal
 			}
 		}


### PR DESCRIPTION
# Description

`BuildProposal` function is changed so it sends `*proto.View` object to the backend implementation, instead just `blockHeight`. The reason for that is because polybft consensus protocol relies on block round as part of consensus data.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Changed `BuildProposal` function signature in the `Backend` interface.

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have added sufficient documentation in code
