### PR TITLE
EVM-220 TestClusterBlockSync/BLS fails in voting power branch

### DIFF
--- a/core/ibft.go
+++ b/core/ibft.go
@@ -22,7 +22,7 @@ type Logger interface {
 // Messages represents the message managing behaviour
 type Messages interface {
 	// Messages modifiers //
-	AddMessage(message *proto.Message)
+	AddMessage(message *proto.Message, shouldSignalEvent func([]*proto.Message) bool)
 	PruneByHeight(height uint64)
 
 	// Messages fetchers //
@@ -998,7 +998,9 @@ func (i *IBFT) AddMessage(message *proto.Message) {
 
 	// Check if the message should even be considered
 	if i.isAcceptableMessage(message) {
-		i.messages.AddMessage(message)
+		i.messages.AddMessage(message, func(allMessages []*proto.Message) bool {
+			return i.backend.HasQuorum(message.View.Height, allMessages, message.Type)
+		})
 	}
 }
 

--- a/core/ibft.go
+++ b/core/ibft.go
@@ -253,7 +253,9 @@ func (i *IBFT) watchForRoundChangeCertificates(ctx context.Context) {
 				Round:  round + 1, // only for higher rounds
 			},
 			HasMinRound: true,
-			HasQuorumFn: i.backend.HasQuorum,
+			HasQuorumFn: func(_ uint64, messages []*proto.Message, _ proto.MessageType) bool {
+				return len(messages) >= 1
+			},
 		})
 	)
 

--- a/core/ibft.go
+++ b/core/ibft.go
@@ -545,7 +545,9 @@ func (i *IBFT) runNewRound(ctx context.Context) error {
 			messages.SubscriptionDetails{
 				MessageType: proto.MessageType_PREPREPARE,
 				View:        view,
-				HasQuorumFn: i.backend.HasQuorum,
+				HasQuorumFn: func(_ uint64, messages []*proto.Message, _ proto.MessageType) bool {
+					return len(messages) >= 1
+				},
 			},
 		)
 	)

--- a/core/ibft.go
+++ b/core/ibft.go
@@ -1051,6 +1051,8 @@ func (i *IBFT) validPC(
 		return false
 	}
 
+	// Order of messages is important!
+	// Mesage with type of MessageType_PREPREPARE must be the first element of allMessages slice
 	allMessages := append(
 		[]*proto.Message{certificate.ProposalMessage},
 		certificate.PrepareMessages...,

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -234,6 +234,7 @@ func (l mockLogger) Error(msg string, args ...interface{}) {
 type mockMessages struct {
 	addMessageFn    func(message *proto.Message)
 	pruneByHeightFn func(height uint64)
+	signalEventFn   func(message *proto.Message)
 
 	getValidMessagesFn func(
 		view *proto.View,
@@ -281,6 +282,12 @@ func (m mockMessages) AddMessage(msg *proto.Message) {
 func (m mockMessages) PruneByHeight(height uint64) {
 	if m.pruneByHeightFn != nil {
 		m.pruneByHeightFn(height)
+	}
+}
+
+func (m mockMessages) SignalEvent(msg *proto.Message) {
+	if m.signalEventFn != nil {
+		m.signalEventFn(msg)
 	}
 }
 

--- a/messages/messages_test.go
+++ b/messages/messages_test.go
@@ -84,7 +84,7 @@ func TestMessages_AddMessage(t *testing.T) {
 	)
 
 	for _, message := range randomMessages {
-		messages.AddMessage(message, func(m []*proto.Message) bool { return true })
+		messages.AddMessage(message)
 	}
 
 	// Make sure that the messages are present
@@ -120,7 +120,7 @@ func TestMessages_AddDuplicates(t *testing.T) {
 
 	for _, message := range randomMessages {
 		message.From = []byte(commonSender)
-		messages.AddMessage(message, func(m []*proto.Message) bool { return true })
+		messages.AddMessage(message)
 	}
 
 	// Check that only 1 message has been added
@@ -161,7 +161,7 @@ func TestMessages_Prune(t *testing.T) {
 	}
 
 	for _, message := range randomMessages {
-		messages.AddMessage(message, func(m []*proto.Message) bool { return true })
+		messages.AddMessage(message)
 	}
 
 	// Prune out the messages from this view
@@ -236,7 +236,7 @@ func TestMessages_GetValidMessagesMessage(t *testing.T) {
 
 			// Add the messages to the corresponding queue
 			for _, message := range randomMessages {
-				messages.AddMessage(message, func(m []*proto.Message) bool { return true })
+				messages.AddMessage(message)
 			}
 
 			// Make sure the messages are there
@@ -298,7 +298,7 @@ func TestMessages_GetMostRoundChangeMessages(t *testing.T) {
 	// Add the messages
 	for _, roundMessages := range randomMessages {
 		for _, message := range roundMessages {
-			messages.AddMessage(message, func(m []*proto.Message) bool { return true })
+			messages.AddMessage(message)
 		}
 	}
 
@@ -340,7 +340,8 @@ func TestMessages_EventManager(t *testing.T) {
 	// Push random messages
 	randomMessages := generateRandomMessages(numMessages, baseView, messageType)
 	for _, message := range randomMessages {
-		messages.AddMessage(message, func(m []*proto.Message) bool { return true })
+		messages.AddMessage(message)
+		messages.SignalEvent(message)
 	}
 
 	// Wait for the subscription event to happen

--- a/messages/messages_test.go
+++ b/messages/messages_test.go
@@ -84,7 +84,7 @@ func TestMessages_AddMessage(t *testing.T) {
 	)
 
 	for _, message := range randomMessages {
-		messages.AddMessage(message)
+		messages.AddMessage(message, func(m []*proto.Message) bool { return true })
 	}
 
 	// Make sure that the messages are present
@@ -120,7 +120,7 @@ func TestMessages_AddDuplicates(t *testing.T) {
 
 	for _, message := range randomMessages {
 		message.From = []byte(commonSender)
-		messages.AddMessage(message)
+		messages.AddMessage(message, func(m []*proto.Message) bool { return true })
 	}
 
 	// Check that only 1 message has been added
@@ -161,7 +161,7 @@ func TestMessages_Prune(t *testing.T) {
 	}
 
 	for _, message := range randomMessages {
-		messages.AddMessage(message)
+		messages.AddMessage(message, func(m []*proto.Message) bool { return true })
 	}
 
 	// Prune out the messages from this view
@@ -236,7 +236,7 @@ func TestMessages_GetValidMessagesMessage(t *testing.T) {
 
 			// Add the messages to the corresponding queue
 			for _, message := range randomMessages {
-				messages.AddMessage(message)
+				messages.AddMessage(message, func(m []*proto.Message) bool { return true })
 			}
 
 			// Make sure the messages are there
@@ -298,7 +298,7 @@ func TestMessages_GetMostRoundChangeMessages(t *testing.T) {
 	// Add the messages
 	for _, roundMessages := range randomMessages {
 		for _, message := range roundMessages {
-			messages.AddMessage(message)
+			messages.AddMessage(message, func(m []*proto.Message) bool { return true })
 		}
 	}
 
@@ -340,7 +340,7 @@ func TestMessages_EventManager(t *testing.T) {
 	// Push random messages
 	randomMessages := generateRandomMessages(numMessages, baseView, messageType)
 	for _, message := range randomMessages {
-		messages.AddMessage(message)
+		messages.AddMessage(message, func(m []*proto.Message) bool { return true })
 	}
 
 	// Wait for the subscription event to happen


### PR DESCRIPTION
# Description

The changes introduced by https://github.com/0xPolygon/go-ibft/pull/39 made a bug inside `func (ms *Messages) AddMessage(message *proto.Message)`. 
Event Manager executed `signalEvent` each time new `*proto.Message` was added to the `muxMap map[proto.MessageType]*sync.RWMutex`.

Before pr mentioned above, there was parameter `totalMessages int,` inside `func (es *eventSubscription) eventSupported`. The parameter was set using `Quorum` function and propagated from `ibft::AddMessage`.  Later on, it was used to check if current round has enough messages of some type. Only in case when number of messages reached desired quorum actual notification was sent to all the subscribers. 

After changes, we lost that quorum check. And consequence of that is that each subscriber (for example subscriber inside `func (i *IBFT) runCommit(ctx context.Context) error`) got notified and executed its handler each time new message of desired type has been added to the "queue".

Solution is to check if quorum is reached on each successful call to `ibft::AddMessage` and signals event only if enough number of messages of same type in current round reached quorum.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have added sufficient documentation in code

# Additional comments

Without these changes `TestClusterBlockSync/BLS` failed more than 80% of the time on CI. With this fix, 150 iterations of the same test passes. And then two more executions - 5 and 20 iterations each passes
