### PR TITLE
Remove redundant changeState

### DIFF
--- a/core/ibft.go
+++ b/core/ibft.go
@@ -569,10 +569,8 @@ func (i *IBFT) runNewRound(ctx context.Context) error {
 				continue
 			}
 
-			// Accept the proposal since it's valid
-			i.acceptProposal(proposalMessage)
-
 			// Multicast the PREPARE message
+			i.state.setProposalMessage(proposalMessage)
 			i.sendPrepareMessage(view)
 
 			i.log.Debug("prepare message multicasted")


### PR DESCRIPTION
# Description

Audit is in progress. Current auditors have noticed redundant call of `state.changeState()`. Since it already happens within `acceptProposal()` method, one must be removed. Since other occurrences of changeState are explicit, `acceptProposal` call is removed and missing innards are moved outside.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [x] I have added sufficient documentation in code

