### PR TITLE
Fix  Wrong Round Value in Validation of roundsAndPreparedBlockHashes

### DIFF
--- a/core/ibft.go
+++ b/core/ibft.go
@@ -689,7 +689,7 @@ func (i *IBFT) validateProposal(msg *proto.Message, view *proto.View) bool {
 			hash := messages.ExtractProposalHash(cert.ProposalMessage)
 
 			roundsAndPreparedBlockHashes = append(roundsAndPreparedBlockHashes, roundHashTuple{
-				round: rcMessage.View.Round,
+				round: cert.ProposalMessage.View.Round,
 				hash:  hash,
 			})
 		}


### PR DESCRIPTION
# Description

Fix the wrong round value in `roundsAndPreparedBlockHashes` based on auditors's comment

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have added sufficient documentation in code

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
