### PR TITLE
Fix wrong selection of proposed block from previous round in non-zero…

### DIFF
--- a/core/ibft.go
+++ b/core/ibft.go
@@ -481,7 +481,8 @@ func (i *IBFT) handleRoundChangeMessage(view *proto.View) *proto.RoundChangeCert
 
 		msgsByRound[msgRound] = append(msgsByRound[msgRound], msgs[idx])
 
-		if msgRound > highestRound && i.backend.HasQuorum(view.Height, msgsByRound[msgRound], proto.MessageType_ROUND_CHANGE) {
+		if msgRound > highestRound &&
+			i.backend.HasQuorum(view.Height, msgsByRound[msgRound], proto.MessageType_ROUND_CHANGE) {
 			highestRound = msgRound
 		}
 	}

--- a/core/ibft.go
+++ b/core/ibft.go
@@ -987,6 +987,7 @@ func (i *IBFT) buildProposal(ctx context.Context, view *proto.View) *proto.Messa
 
 		if msgRound > maxRound {
 			previousProposal = lastPB
+			maxRound = msgRound
 		}
 	}
 

--- a/core/ibft.go
+++ b/core/ibft.go
@@ -36,7 +36,7 @@ type Messages interface {
 	GetExtendedRCC(
 		height uint64,
 		isValidMessage func(message *proto.Message) bool,
-		isValidRCC func(round uint64, messages []*proto.Message) bool,
+		isValidRCC func(round uint64, msgs []*proto.Message) bool,
 	) []*proto.Message
 	GetMostRoundChangeMessages(minRound, height uint64) []*proto.Message
 
@@ -456,14 +456,14 @@ func (i *IBFT) handleRoundChangeMessage(view *proto.View) *proto.RoundChangeCert
 		return i.proposalMatchesCertificate(proposal, certificate)
 	}
 
-	isValidRCCFn := func(round uint64, messages []*proto.Message) bool {
+	isValidRCCFn := func(round uint64, msgs []*proto.Message) bool {
 		// In case of that ROUND-CHANGE message's round match validator's round
 		// Accept such messages only if the validator has not accepted a proposal at the round
 		if round == view.Round && hasAcceptedProposal {
 			return false
 		}
 
-		return i.backend.HasQuorum(height, messages, proto.MessageType_ROUND_CHANGE)
+		return i.backend.HasQuorum(height, msgs, proto.MessageType_ROUND_CHANGE)
 	}
 
 	extendedRCC := i.messages.GetExtendedRCC(

--- a/core/ibft.go
+++ b/core/ibft.go
@@ -481,8 +481,7 @@ func (i *IBFT) handleRoundChangeMessage(view *proto.View) *proto.RoundChangeCert
 
 		msgsByRound[msgRound] = append(msgsByRound[msgRound], msgs[idx])
 
-		if i.backend.HasQuorum(view.Height, msgsByRound[msgRound], proto.MessageType_ROUND_CHANGE) &&
-			msgRound > highestRound {
+		if msgRound > highestRound && i.backend.HasQuorum(view.Height, msgsByRound[msgRound], proto.MessageType_ROUND_CHANGE) {
 			highestRound = msgRound
 		}
 	}

--- a/core/ibft_test.go
+++ b/core/ibft_test.go
@@ -544,12 +544,10 @@ func TestRunNewRound_Proposer(t *testing.T) {
 						isValidMessage func(message *proto.Message) bool,
 						isValidRCC func(round uint64, messages []*proto.Message) bool,
 					) []*proto.Message {
-						messages := filterMessages(
+						return filterMessages(
 							roundChangeMessages,
 							isValidMessage,
 						)
-
-						return messages
 					},
 				}
 			)

--- a/core/ibft_test.go
+++ b/core/ibft_test.go
@@ -375,6 +375,16 @@ func TestRunNewRound_Proposer(t *testing.T) {
 							isValid,
 						)
 					},
+					getExtendedRCCFn: func(
+						height uint64,
+						isValidMessage func(message *proto.Message) bool,
+						isValidRCC func(round uint64, messages []*proto.Message,
+						) bool) []*proto.Message {
+						return filterMessages(
+							roundChangeMessages,
+							isValidMessage,
+						)
+					},
 				}
 			)
 
@@ -528,6 +538,18 @@ func TestRunNewRound_Proposer(t *testing.T) {
 							roundChangeMessages,
 							isValid,
 						)
+					},
+					getExtendedRCCFn: func(
+						height uint64,
+						isValidMessage func(message *proto.Message) bool,
+						isValidRCC func(round uint64, messages []*proto.Message) bool,
+					) []*proto.Message {
+						messages := filterMessages(
+							roundChangeMessages,
+							isValidMessage,
+						)
+
+						return messages
 					},
 				}
 			)
@@ -2093,6 +2115,27 @@ func TestIBFT_WatchForFutureRCC(t *testing.T) {
 					roundChangeMessages,
 					isValid,
 				)
+			},
+			getExtendedRCCFn: func(
+				height uint64,
+				isValidMessage func(message *proto.Message) bool,
+				isValidRCC func(round uint64, messages []*proto.Message) bool,
+			) []*proto.Message {
+				messages := filterMessages(
+					roundChangeMessages,
+					isValidMessage,
+				)
+
+				if len(messages) == 0 {
+					return nil
+				}
+
+				round := messages[0].View.Round
+				if !isValidRCC(round, messages) {
+					return nil
+				}
+
+				return messages
 			},
 		}
 	)

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -241,6 +241,11 @@ type mockMessages struct {
 		messageType proto.MessageType,
 		isValid func(message *proto.Message) bool,
 	) []*proto.Message
+	getExtendedRCCFn func(
+		height uint64,
+		isValidMessage func(message *proto.Message) bool,
+		isValidRCC func(round uint64, messages []*proto.Message) bool,
+	) []*proto.Message
 	getMostRoundChangeMessagesFn func(uint64, uint64) []*proto.Message
 
 	subscribeFn   func(details messages.SubscriptionDetails) *messages.Subscription
@@ -289,6 +294,18 @@ func (m mockMessages) SignalEvent(msg *proto.Message) {
 	if m.signalEventFn != nil {
 		m.signalEventFn(msg)
 	}
+}
+
+func (m mockMessages) GetExtendedRCC(
+	height uint64,
+	isValidMessage func(message *proto.Message) bool,
+	isValidRCC func(round uint64, messages []*proto.Message) bool,
+) []*proto.Message {
+	if m.getExtendedRCCFn != nil {
+		return m.getExtendedRCCFn(height, isValidMessage, isValidRCC)
+	}
+
+	return nil
 }
 
 func (m mockMessages) GetMostRoundChangeMessages(round, height uint64) []*proto.Message {

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -235,6 +235,10 @@ func (ms *Messages) GetExtendedRCC(
 	for round, messages := range roundMessageMap {
 		validMessages := make([]*proto.Message, 0, len(messages))
 
+		if round <= highestRound {
+			continue
+		}
+
 		for _, msg := range messages {
 			if !isValidMessage(msg) {
 				continue
@@ -243,7 +247,7 @@ func (ms *Messages) GetExtendedRCC(
 			validMessages = append(validMessages, msg)
 		}
 
-		if round <= highestRound || !isValidRCC(round, validMessages) {
+		if !isValidRCC(round, validMessages) {
 			continue
 		}
 

--- a/messages/messages_test.go
+++ b/messages/messages_test.go
@@ -275,7 +275,7 @@ func TestMessages_GetExtendedRCC(t *testing.T) {
 
 	var (
 		height uint64 = 0
-		quorum int    = 5
+		quorum        = 5
 	)
 
 	messages := NewMessages()

--- a/messages/messages_test.go
+++ b/messages/messages_test.go
@@ -267,6 +267,67 @@ func TestMessages_GetValidMessagesMessage(t *testing.T) {
 	}
 }
 
+// TestMessages_GetExtendedRCC makes sure
+// Messages returns the ROUND-CHANGE messages for the highest round
+// where all messages are valid
+func TestMessages_GetExtendedRCC(t *testing.T) {
+	t.Parallel()
+
+	var (
+		height uint64 = 0
+		quorum int    = 5
+	)
+
+	messages := NewMessages()
+	defer messages.Close()
+
+	// Generate round messages
+	randomMessages := map[uint64][]*proto.Message{
+		0: generateRandomMessages(quorum-1, &proto.View{
+			Height: height,
+			Round:  0,
+		}, proto.MessageType_ROUND_CHANGE),
+
+		1: generateRandomMessages(quorum, &proto.View{
+			Height: height,
+			Round:  1,
+		}, proto.MessageType_ROUND_CHANGE),
+
+		2: generateRandomMessages(quorum, &proto.View{
+			Height: height,
+			Round:  2,
+		}, proto.MessageType_ROUND_CHANGE),
+
+		3: generateRandomMessages(quorum-1, &proto.View{
+			Height: height,
+			Round:  3,
+		}, proto.MessageType_ROUND_CHANGE),
+	}
+
+	// Add the messages
+	for _, roundMessages := range randomMessages {
+		for _, message := range roundMessages {
+			messages.AddMessage(message)
+		}
+	}
+
+	extendedRCC := messages.GetExtendedRCC(
+		height,
+		func(message *proto.Message) bool {
+			return true
+		},
+		func(round uint64, messages []*proto.Message) bool {
+			return len(messages) >= quorum
+		},
+	)
+
+	assert.ElementsMatch(
+		t,
+		randomMessages[2],
+		extendedRCC,
+	)
+}
+
 // TestMessages_GetMostRoundChangeMessages makes sure
 // the round messages for the round with the most round change
 // messages are fetched


### PR DESCRIPTION
# Description

Fix the wrong proposed block selection from the proposed block in previous rounds in `buildProposal ` based on auditors' comments.

According to IBFT 2.0 paper, if round > 0, block proposer must propose block that has been proposed for same height in the round where the round is biggest round in the rounds meeting the following conditions:
+ ROUND-CHANGE messages for the round reaches quorum
+ Prepared-Certificate(PC) is valid
+ All hashes of block included in PROPOSAL and PREPARE in PC equals to each other

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have added sufficient documentation in code

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
