### PR TITLE
Remove redundant code and Add Safe check in bulding committed seals

### DIFF
--- a/core/ibft.go
+++ b/core/ibft.go
@@ -640,7 +640,6 @@ func (i *IBFT) validateProposal(msg *proto.Message, view *proto.View) bool {
 		round  = view.Round
 
 		proposalHash = messages.ExtractProposalHash(msg)
-		certificate  = messages.ExtractRoundChangeCertificate(msg)
 		rcc          = messages.ExtractRoundChangeCertificate(msg)
 	)
 
@@ -650,12 +649,12 @@ func (i *IBFT) validateProposal(msg *proto.Message, view *proto.View) bool {
 	}
 
 	// Make sure there is a certificate
-	if certificate == nil {
+	if rcc == nil {
 		return false
 	}
 
 	// Make sure there are Quorum RCC
-	if !i.backend.HasQuorum(view.Height, certificate.RoundChangeMessages, proto.MessageType_ROUND_CHANGE) {
+	if !i.backend.HasQuorum(view.Height, rcc.RoundChangeMessages, proto.MessageType_ROUND_CHANGE) {
 		return false
 	}
 
@@ -665,7 +664,7 @@ func (i *IBFT) validateProposal(msg *proto.Message, view *proto.View) bool {
 	}
 
 	// Make sure all messages in the RCC are valid Round Change messages
-	for _, rc := range certificate.RoundChangeMessages {
+	for _, rc := range rcc.RoundChangeMessages {
 		// Make sure the message is a Round Change message
 		if rc.Type != proto.MessageType_ROUND_CHANGE {
 			return false

--- a/core/ibft.go
+++ b/core/ibft.go
@@ -878,10 +878,16 @@ func (i *IBFT) handleCommit(view *proto.View) bool {
 		return false
 	}
 
+	commitSeals, err := messages.ExtractCommittedSeals(commitMessages)
+	if err != nil {
+		// safe check
+		i.log.Error("failed to extract committed seals from commit messages: %+v", err)
+
+		return false
+	}
+
 	// Set the committed seals
-	i.state.setCommittedSeals(
-		messages.ExtractCommittedSeals(commitMessages),
-	)
+	i.state.setCommittedSeals(commitSeals)
 
 	//	Move to the fin state
 	i.state.changeState(fin)

--- a/messages/helpers.go
+++ b/messages/helpers.go
@@ -2,6 +2,7 @@ package messages
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/0xPolygon/go-ibft/messages/proto"
 )
@@ -11,19 +12,34 @@ type CommittedSeal struct {
 	Signature []byte
 }
 
+func createWrongMessageTypeError(
+	expected, actual proto.MessageType,
+) error {
+	actualMessageTypeName, ok := proto.MessageType_name[int32(actual)]
+	if !ok {
+		actualMessageTypeName = "undefined"
+	}
+
+	return fmt.Errorf(
+		"wrong message type, expected=%s, got=%s",
+		proto.MessageType_name[int32(expected)],
+		actualMessageTypeName,
+	)
+}
+
 // ExtractCommittedSeals extracts the committed seals from the passed in messages
-func ExtractCommittedSeals(commitMessages []*proto.Message) []*CommittedSeal {
+func ExtractCommittedSeals(commitMessages []*proto.Message) ([]*CommittedSeal, error) {
 	committedSeals := make([]*CommittedSeal, 0)
 
 	for _, commitMessage := range commitMessages {
 		if commitMessage.Type != proto.MessageType_COMMIT {
-			continue
+			return nil, createWrongMessageTypeError(proto.MessageType_COMMIT, commitMessage.Type)
 		}
 
 		committedSeals = append(committedSeals, ExtractCommittedSeal(commitMessage))
 	}
 
-	return committedSeals
+	return committedSeals, nil
 }
 
 // ExtractCommittedSeal extracts the committed seal from the passed in message

--- a/messages/helpers_test.go
+++ b/messages/helpers_test.go
@@ -1,7 +1,6 @@
 package messages
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -66,11 +65,7 @@ func TestMessages_ExtractCommittedSeals(t *testing.T) {
 				createWrongMessage("signer2", proto.MessageType_PREPREPARE),
 			},
 			expected: nil,
-			err: fmt.Errorf(
-				"wrong message type, expected=%s, got=%s",
-				proto.MessageType_name[int32(proto.MessageType_COMMIT)],
-				proto.MessageType_name[int32(proto.MessageType_PREPREPARE)],
-			),
+			err:      ErrWrongCommitMessageType,
 		},
 	}
 
@@ -83,12 +78,7 @@ func TestMessages_ExtractCommittedSeals(t *testing.T) {
 			seals, err := ExtractCommittedSeals(test.messages)
 
 			assert.Equal(t, test.expected, seals)
-
-			if test.err == nil {
-				assert.NoError(t, err)
-			} else {
-				assert.ErrorContains(t, err, test.err.Error())
-			}
+			assert.Equal(t, test.err, err)
 		})
 	}
 }


### PR DESCRIPTION
# Description

Remove redundant  local variables from `validateProposal` and add safe check of wrong message in `ExtractCommittedSeals`, which build committed seals based on auditors' suggestions.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have added sufficient documentation in code

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
