### PR TITLE
Byzantine tests

### DIFF
--- a/core/byzantine_test.go
+++ b/core/byzantine_test.go
@@ -1,0 +1,599 @@
+package core
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/0xPolygon/go-ibft/messages/proto"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestByzantineBehaviour(t *testing.T) {
+	t.Parallel()
+
+	t.Run("malicious hash in proposal", func(t *testing.T) {
+		t.Parallel()
+
+		cluster := newCluster(
+			6,
+			func(c *cluster) {
+				for id, node := range c.nodes {
+					currentNode := node
+					node.core = NewIBFT(
+						testingLogger(id),
+						&mockBackend{
+							isValidBlockFn:         isValidProposal,
+							isValidProposalHashFn:  isValidProposalHash,
+							isValidSenderFn:        nil,
+							isValidCommittedSealFn: nil,
+							isProposerFn: func(from []byte, height uint64, round uint64) bool {
+								if round == 0 {
+									return false
+								}
+
+								return bytes.Equal(
+									from,
+									c.addresses()[int(round)%len(c.addresses())],
+								)
+							},
+
+							idFn: node.addr,
+
+							buildProposalFn: buildValidProposal,
+							buildPrePrepareMessageFn: func(proposal []byte,
+								rcc *proto.RoundChangeCertificate,
+								view *proto.View) *proto.Message {
+								proposalHash := validProposalHash
+								if currentNode.byzantine {
+									proposalHash = []byte("invalid proposal hash")
+								}
+								return buildBasicPreprepareMessage(
+									proposal,
+									proposalHash,
+									rcc,
+									currentNode.address,
+									view,
+								)
+							},
+							buildPrepareMessageFn:     node.buildPrepare,
+							buildCommitMessageFn:      node.buildCommit,
+							buildRoundChangeMessageFn: node.buildRoundChange,
+
+							insertBlockFn: nil,
+							hasQuorumFn:   c.hasQuorumFn,
+						},
+
+						&mockTransport{multicastFn: c.gossip},
+					)
+				}
+			},
+		)
+
+		err := cluster.progressToHeight(20*time.Second, 1)
+		assert.NoError(t, err, "unable to reach height: %w", err)
+		assert.Equal(t, uint64(1), cluster.latestHeight)
+
+		cluster.makeNByzantine(int(cluster.maxFaulty()))
+		assert.NoError(t, cluster.progressToHeight(20*time.Second, 2))
+		assert.Equal(t, uint64(2), cluster.latestHeight)
+	})
+
+	t.Run("malicious hash in prepare", func(t *testing.T) {
+		t.Parallel()
+
+		cluster := newCluster(
+			6,
+			func(c *cluster) {
+				for id, node := range c.nodes {
+					currentNode := node
+					node.core = NewIBFT(
+						testingLogger(id),
+						&mockBackend{
+							isValidBlockFn:         isValidProposal,
+							isValidProposalHashFn:  isValidProposalHash,
+							isValidSenderFn:        nil,
+							isValidCommittedSealFn: nil,
+							isProposerFn:           c.isProposer,
+
+							idFn: node.addr,
+
+							buildProposalFn:          buildValidProposal,
+							buildPrePrepareMessageFn: node.buildPrePrepare,
+							buildPrepareMessageFn: func(_ []byte, view *proto.View) *proto.Message {
+								proposalHash := validProposalHash
+								if currentNode.byzantine {
+									proposalHash = []byte("invalid proposal hash")
+								}
+								return buildBasicPrepareMessage(
+									proposalHash,
+									currentNode.address,
+									view,
+								)
+							},
+							buildCommitMessageFn:      node.buildCommit,
+							buildRoundChangeMessageFn: node.buildRoundChange,
+
+							insertBlockFn: nil,
+							hasQuorumFn:   c.hasQuorumFn,
+						},
+
+						&mockTransport{multicastFn: c.gossip},
+					)
+				}
+			},
+		)
+
+		err := cluster.progressToHeight(10*time.Second, 1)
+		assert.NoError(t, err, "unable to reach height: %w", err)
+		assert.Equal(t, uint64(1), cluster.latestHeight)
+
+		cluster.makeNByzantine(int(cluster.maxFaulty()))
+		assert.NoError(t, cluster.progressToHeight(10*time.Second, 2))
+		assert.Equal(t, uint64(2), cluster.latestHeight)
+	})
+
+	t.Run("malicious +1 round in proposal", func(t *testing.T) {
+		t.Parallel()
+
+		cluster := newCluster(
+			6,
+			func(c *cluster) {
+				for id, node := range c.nodes {
+					currentNode := node
+					node.core = NewIBFT(
+						testingLogger(id),
+						&mockBackend{
+							isValidBlockFn:         isValidProposal,
+							isValidProposalHashFn:  isValidProposalHash,
+							isValidSenderFn:        nil,
+							isValidCommittedSealFn: nil,
+							isProposerFn: func(from []byte, height uint64, round uint64) bool {
+								if round == 0 {
+									return false
+								}
+
+								return bytes.Equal(
+									from,
+									c.addresses()[int(round)%len(c.addresses())],
+								)
+							},
+
+							idFn: node.addr,
+
+							buildProposalFn: buildValidProposal,
+							buildPrePrepareMessageFn: func(
+								proposal []byte,
+								certificate *proto.RoundChangeCertificate,
+								view *proto.View,
+							) *proto.Message {
+								fmt.Println(currentNode.address)
+								currentNode.core.log.Debug(fmt.Sprint("TERE ", view, currentNode.byzantine))
+								if currentNode.byzantine {
+									view.Round = uint64(rand.Int())
+								}
+								return buildBasicPreprepareMessage(
+									proposal,
+									validProposalHash,
+									certificate,
+									currentNode.address,
+									view,
+								)
+							},
+							buildPrepareMessageFn:     node.buildPrepare,
+							buildCommitMessageFn:      node.buildCommit,
+							buildRoundChangeMessageFn: node.buildRoundChange,
+
+							insertBlockFn: nil,
+							hasQuorumFn:   c.hasQuorumFn,
+						},
+
+						&mockTransport{multicastFn: c.gossip},
+					)
+				}
+			},
+		)
+
+		err := cluster.progressToHeight(20*time.Second, 1)
+		assert.NoError(t, err, "unable to reach height: %w", err)
+		assert.Equal(t, uint64(1), cluster.latestHeight)
+
+		// Max tolerant byzantine
+		cluster.makeNByzantine(int(cluster.maxFaulty()))
+		assert.NoError(t, cluster.progressToHeight(40*time.Second, 2))
+		assert.Equal(t, uint64(2), cluster.latestHeight)
+	})
+
+	t.Run("malicious +1 round in rcc", func(t *testing.T) {
+		t.Parallel()
+
+		cluster := newCluster(
+			6,
+			func(c *cluster) {
+				for id, node := range c.nodes {
+					currentNode := node
+					node.core = NewIBFT(
+						testingLogger(id),
+						&mockBackend{
+							isValidBlockFn:         isValidProposal,
+							isValidProposalHashFn:  isValidProposalHash,
+							isValidSenderFn:        nil,
+							isValidCommittedSealFn: nil,
+							isProposerFn: func(from []byte, height uint64, round uint64) bool {
+								if round == 0 {
+									return false
+								}
+
+								return bytes.Equal(
+									from,
+									c.addresses()[int(round)%len(c.addresses())],
+								)
+							},
+							idFn: node.addr,
+
+							buildProposalFn:          buildValidProposal,
+							buildPrePrepareMessageFn: node.buildPrePrepare,
+							buildPrepareMessageFn:    node.buildPrepare,
+							buildCommitMessageFn:     node.buildCommit,
+							buildRoundChangeMessageFn: func(proposal []byte,
+								rcc *proto.PreparedCertificate,
+								view *proto.View) *proto.Message {
+								if currentNode.byzantine {
+									view.Round++
+								}
+
+								return buildBasicRoundChangeMessage(
+									proposal,
+									rcc,
+									view,
+									currentNode.address,
+								)
+							},
+
+							insertBlockFn: nil,
+							hasQuorumFn:   c.hasQuorumFn,
+						},
+
+						&mockTransport{multicastFn: c.gossip},
+					)
+				}
+			},
+		)
+
+		err := cluster.progressToHeight(20*time.Second, 1)
+		assert.NoError(t, err, "unable to reach height: %w", err)
+		assert.Equal(t, uint64(1), cluster.latestHeight)
+
+		cluster.makeNByzantine(int(cluster.maxFaulty()))
+		assert.NoError(t, cluster.progressToHeight(30*time.Second, 2))
+		assert.Equal(t, uint64(2), cluster.latestHeight)
+	})
+
+	t.Run("malicious +1 round in rcc and in proposal", func(t *testing.T) {
+		t.Parallel()
+
+		cluster := newCluster(
+			6,
+			func(c *cluster) {
+				for id, node := range c.nodes {
+					currentNode := node
+					node.core = NewIBFT(
+						testingLogger(id),
+						&mockBackend{
+							isValidBlockFn:         isValidProposal,
+							isValidProposalHashFn:  isValidProposalHash,
+							isValidSenderFn:        nil,
+							isValidCommittedSealFn: nil,
+							isProposerFn: func(from []byte, height uint64, round uint64) bool {
+								if round == 0 {
+									return false
+								}
+
+								return bytes.Equal(
+									from,
+									c.addresses()[int(round)%len(c.addresses())],
+								)
+							},
+							idFn: node.addr,
+
+							buildProposalFn: buildValidProposal,
+							buildPrePrepareMessageFn: func(
+								proposal []byte,
+								certificate *proto.RoundChangeCertificate,
+								view *proto.View,
+							) *proto.Message {
+								fmt.Println(currentNode.address)
+								currentNode.core.log.Debug(fmt.Sprint("TERE ", view, currentNode.byzantine))
+								if currentNode.byzantine {
+									view.Round = uint64(rand.Int())
+								}
+								return buildBasicPreprepareMessage(
+									proposal,
+									validProposalHash,
+									certificate,
+									currentNode.address,
+									view,
+								)
+							},
+							buildPrepareMessageFn: node.buildPrepare,
+							buildCommitMessageFn:  node.buildCommit,
+							buildRoundChangeMessageFn: func(proposal []byte,
+								rcc *proto.PreparedCertificate,
+								view *proto.View) *proto.Message {
+								if currentNode.byzantine {
+									view.Round++
+								}
+
+								return buildBasicRoundChangeMessage(
+									proposal,
+									rcc,
+									view,
+									currentNode.address,
+								)
+							},
+
+							insertBlockFn: nil,
+							hasQuorumFn:   c.hasQuorumFn,
+						},
+
+						&mockTransport{multicastFn: c.gossip},
+					)
+				}
+			},
+		)
+
+		err := cluster.progressToHeight(20*time.Second, 1)
+		assert.NoError(t, err, "unable to reach height: %w", err)
+		assert.Equal(t, uint64(1), cluster.latestHeight)
+
+		cluster.makeNByzantine(int(cluster.maxFaulty()))
+		assert.NoError(t, cluster.progressToHeight(30*time.Second, 2))
+		assert.Equal(t, uint64(2), cluster.latestHeight)
+	})
+
+	t.Run("malicious +1 round in rcc and bad hash in proposal", func(t *testing.T) {
+		t.Parallel()
+
+		cluster := newCluster(
+			6,
+			func(c *cluster) {
+				for id, node := range c.nodes {
+					currentNode := node
+					node.core = NewIBFT(
+						testingLogger(id),
+						&mockBackend{
+							isValidBlockFn:         isValidProposal,
+							isValidProposalHashFn:  isValidProposalHash,
+							isValidSenderFn:        nil,
+							isValidCommittedSealFn: nil,
+							isProposerFn: func(from []byte, height uint64, round uint64) bool {
+								if round == 0 {
+									return false
+								}
+
+								return bytes.Equal(
+									from,
+									c.addresses()[int(round)%len(c.addresses())],
+								)
+							},
+							idFn: node.addr,
+
+							buildProposalFn: buildValidProposal,
+							buildPrePrepareMessageFn: func(proposal []byte,
+								rcc *proto.RoundChangeCertificate,
+								view *proto.View) *proto.Message {
+								proposalHash := validProposalHash
+								if currentNode.byzantine {
+									proposalHash = []byte("invalid proposal hash")
+								}
+								return buildBasicPreprepareMessage(
+									proposal,
+									proposalHash,
+									rcc,
+									currentNode.address,
+									view,
+								)
+							},
+							buildPrepareMessageFn: node.buildPrepare,
+							buildCommitMessageFn:  node.buildCommit,
+							buildRoundChangeMessageFn: func(proposal []byte,
+								rcc *proto.PreparedCertificate,
+								view *proto.View) *proto.Message {
+								if currentNode.byzantine {
+									view.Round++
+								}
+
+								return buildBasicRoundChangeMessage(
+									proposal,
+									rcc,
+									view,
+									currentNode.address,
+								)
+							},
+
+							insertBlockFn: nil,
+							hasQuorumFn:   c.hasQuorumFn,
+						},
+
+						&mockTransport{multicastFn: c.gossip},
+					)
+				}
+			},
+		)
+
+		err := cluster.progressToHeight(20*time.Second, 1)
+		assert.NoError(t, err, "unable to reach height: %w", err)
+		assert.Equal(t, uint64(1), cluster.latestHeight)
+
+		cluster.makeNByzantine(int(cluster.maxFaulty()))
+		assert.NoError(t, cluster.progressToHeight(30*time.Second, 2))
+		assert.Equal(t, uint64(2), cluster.latestHeight)
+	})
+
+	t.Run("malicious +1 round in rcc and bad hash in prepare", func(t *testing.T) {
+		t.Parallel()
+
+		cluster := newCluster(
+			6,
+			func(c *cluster) {
+				for id, node := range c.nodes {
+					currentNode := node
+					node.core = NewIBFT(
+						testingLogger(id),
+						&mockBackend{
+							isValidBlockFn:         isValidProposal,
+							isValidProposalHashFn:  isValidProposalHash,
+							isValidSenderFn:        nil,
+							isValidCommittedSealFn: nil,
+							isProposerFn: func(from []byte, height uint64, round uint64) bool {
+								if round == 0 {
+									return false
+								}
+
+								return bytes.Equal(
+									from,
+									c.addresses()[int(round)%len(c.addresses())],
+								)
+							},
+							idFn: node.addr,
+
+							buildProposalFn:          buildValidProposal,
+							buildPrePrepareMessageFn: node.buildPrePrepare,
+							buildPrepareMessageFn: func(_ []byte, view *proto.View) *proto.Message {
+								proposalHash := validProposalHash
+								if currentNode.byzantine {
+									proposalHash = []byte("invalid proposal hash")
+								}
+								return buildBasicPrepareMessage(
+									proposalHash,
+									currentNode.address,
+									view,
+								)
+							},
+							buildCommitMessageFn: node.buildCommit,
+							buildRoundChangeMessageFn: func(proposal []byte,
+								rcc *proto.PreparedCertificate,
+								view *proto.View) *proto.Message {
+								if currentNode.byzantine {
+									view.Round++
+								}
+
+								return buildBasicRoundChangeMessage(
+									proposal,
+									rcc,
+									view,
+									currentNode.address,
+								)
+							},
+
+							insertBlockFn: nil,
+							hasQuorumFn:   c.hasQuorumFn,
+						},
+
+						&mockTransport{multicastFn: c.gossip},
+					)
+				}
+			},
+		)
+
+		err := cluster.progressToHeight(20*time.Second, 1)
+		assert.NoError(t, err, "unable to reach height: %w", err)
+		assert.Equal(t, uint64(1), cluster.latestHeight)
+
+		cluster.makeNByzantine(int(cluster.maxFaulty()))
+		assert.NoError(t, cluster.progressToHeight(30*time.Second, 2))
+		assert.Equal(t, uint64(2), cluster.latestHeight)
+	})
+
+	t.Run("malicious +1 round in rcc and bad commit seal", func(t *testing.T) {
+		t.Parallel()
+
+		cluster := newCluster(
+			6,
+			func(c *cluster) {
+				for id, node := range c.nodes {
+					currentNode := node
+					node.core = NewIBFT(
+						testingLogger(id),
+						&mockBackend{
+							isValidBlockFn:         isValidProposal,
+							isValidProposalHashFn:  isValidProposalHash,
+							isValidSenderFn:        nil,
+							isValidCommittedSealFn: nil,
+							isProposerFn: func(from []byte, height uint64, round uint64) bool {
+								if round == 0 {
+									return false
+								}
+
+								return bytes.Equal(
+									from,
+									c.addresses()[int(round)%len(c.addresses())],
+								)
+							},
+							idFn: node.addr,
+
+							buildProposalFn:          buildValidProposal,
+							buildPrePrepareMessageFn: node.buildPrePrepare,
+							buildPrepareMessageFn:    node.buildPrepare,
+							buildCommitMessageFn: func(_ []byte, view *proto.View) *proto.Message {
+								committedSeal := validCommittedSeal
+								if currentNode.byzantine {
+									committedSeal = []byte("invalid committed seal")
+								}
+								return buildBasicCommitMessage(
+									validProposalHash,
+									committedSeal,
+									currentNode.address,
+									view,
+								)
+							},
+							buildRoundChangeMessageFn: func(proposal []byte,
+								rcc *proto.PreparedCertificate,
+								view *proto.View) *proto.Message {
+								if currentNode.byzantine {
+									view.Round++
+								}
+
+								return buildBasicRoundChangeMessage(
+									proposal,
+									rcc,
+									view,
+									currentNode.address,
+								)
+							},
+
+							insertBlockFn: nil,
+							hasQuorumFn:   c.hasQuorumFn,
+						},
+
+						&mockTransport{multicastFn: c.gossip},
+					)
+				}
+			},
+		)
+
+		err := cluster.progressToHeight(20*time.Second, 1)
+		assert.NoError(t, err, "unable to reach height: %w", err)
+		assert.Equal(t, uint64(1), cluster.latestHeight)
+
+		cluster.makeNByzantine(int(cluster.maxFaulty()))
+		assert.NoError(t, cluster.progressToHeight(30*time.Second, 2))
+		assert.Equal(t, uint64(2), cluster.latestHeight)
+	})
+}
+
+func testingLogger(nodeId int) *mockLogger {
+	return &mockLogger{
+		infoFn: func(s string, _ ...interface{}) {
+			fmt.Printf("[Node %d]: %s\n", nodeId, s)
+		},
+		debugFn: func(s string, _ ...interface{}) {
+			fmt.Printf("[Node %d]: %s\n", nodeId, s)
+		},
+		errorFn: func(s string, _ ...interface{}) {
+			fmt.Printf("[Node %d]: %s\n", nodeId, s)
+		},
+	}
+}

--- a/core/byzantine_test.go
+++ b/core/byzantine_test.go
@@ -23,7 +23,7 @@ func TestByzantineBehaviour(t *testing.T) {
 
 					backendBuilder := mockBackendBuilder{}
 					backendBuilder.withProposerFn(createForcedRCProposerFn(c))
-					backendBuilder.withIdFn(currentNode.addr)
+					backendBuilder.withIDFn(currentNode.addr)
 					backendBuilder.withBuildPrePrepareMessageFn(createBadHashPrePrepareMessageFn(currentNode))
 					backendBuilder.withHasQuorumFn(c.hasQuorumFn)
 
@@ -56,7 +56,7 @@ func TestByzantineBehaviour(t *testing.T) {
 
 					backendBuilder := mockBackendBuilder{}
 					backendBuilder.withProposerFn(c.isProposer)
-					backendBuilder.withIdFn(currentNode.addr)
+					backendBuilder.withIDFn(currentNode.addr)
 					backendBuilder.withBuildPrepareMessageFn(createBadHashPrepareMessageFn(currentNode))
 					backendBuilder.withHasQuorumFn(c.hasQuorumFn)
 
@@ -89,7 +89,7 @@ func TestByzantineBehaviour(t *testing.T) {
 
 					backendBuilder := mockBackendBuilder{}
 					backendBuilder.withProposerFn(createForcedRCProposerFn(c))
-					backendBuilder.withIdFn(currentNode.addr)
+					backendBuilder.withIDFn(currentNode.addr)
 					backendBuilder.withBuildPrePrepareMessageFn(createBadRoundPrePrepareMessageFn(currentNode))
 					backendBuilder.withHasQuorumFn(c.hasQuorumFn)
 
@@ -123,7 +123,7 @@ func TestByzantineBehaviour(t *testing.T) {
 
 					backendBuilder := mockBackendBuilder{}
 					backendBuilder.withProposerFn(createForcedRCProposerFn(c))
-					backendBuilder.withIdFn(currentNode.addr)
+					backendBuilder.withIDFn(currentNode.addr)
 					backendBuilder.withBuildRoundChangeMessageFn(createBadRoundRoundChangeFn(currentNode))
 					backendBuilder.withHasQuorumFn(c.hasQuorumFn)
 
@@ -156,7 +156,7 @@ func TestByzantineBehaviour(t *testing.T) {
 
 					backendBuilder := mockBackendBuilder{}
 					backendBuilder.withProposerFn(createForcedRCProposerFn(c))
-					backendBuilder.withIdFn(currentNode.addr)
+					backendBuilder.withIDFn(currentNode.addr)
 					backendBuilder.withBuildPrePrepareMessageFn(createBadRoundPrePrepareMessageFn(currentNode))
 					backendBuilder.withBuildRoundChangeMessageFn(createBadRoundRoundChangeFn(currentNode))
 					backendBuilder.withHasQuorumFn(c.hasQuorumFn)
@@ -190,7 +190,7 @@ func TestByzantineBehaviour(t *testing.T) {
 
 					backendBuilder := mockBackendBuilder{}
 					backendBuilder.withProposerFn(createForcedRCProposerFn(c))
-					backendBuilder.withIdFn(currentNode.addr)
+					backendBuilder.withIDFn(currentNode.addr)
 					backendBuilder.withBuildPrePrepareMessageFn(createBadHashPrePrepareMessageFn(currentNode))
 					backendBuilder.withBuildRoundChangeMessageFn(createBadRoundRoundChangeFn(currentNode))
 					backendBuilder.withHasQuorumFn(c.hasQuorumFn)
@@ -224,7 +224,7 @@ func TestByzantineBehaviour(t *testing.T) {
 
 					backendBuilder := mockBackendBuilder{}
 					backendBuilder.withProposerFn(createForcedRCProposerFn(c))
-					backendBuilder.withIdFn(currentNode.addr)
+					backendBuilder.withIDFn(currentNode.addr)
 					backendBuilder.withBuildPrepareMessageFn(createBadHashPrepareMessageFn(currentNode))
 					backendBuilder.withBuildRoundChangeMessageFn(createBadRoundRoundChangeFn(currentNode))
 					backendBuilder.withHasQuorumFn(c.hasQuorumFn)
@@ -258,7 +258,7 @@ func TestByzantineBehaviour(t *testing.T) {
 
 					backendBuilder := mockBackendBuilder{}
 					backendBuilder.withProposerFn(createForcedRCProposerFn(c))
-					backendBuilder.withIdFn(currentNode.addr)
+					backendBuilder.withIDFn(currentNode.addr)
 					backendBuilder.withBuildCommitMessageFn(createBadCommitMessageFn(currentNode))
 					backendBuilder.withBuildRoundChangeMessageFn(createBadRoundRoundChangeFn(currentNode))
 					backendBuilder.withHasQuorumFn(c.hasQuorumFn)
@@ -387,7 +387,6 @@ type mockBackendBuilder struct {
 
 	idFn idDelegate
 
-	buildProposalFn           buildProposalDelegate
 	buildPrePrepareMessageFn  buildPrePrepareMessageDelegate
 	buildPrepareMessageFn     buildPrepareMessageDelegate
 	buildCommitMessageFn      buildCommitMessageDelegate
@@ -398,10 +397,6 @@ type mockBackendBuilder struct {
 
 func (b *mockBackendBuilder) withProposerFn(f isProposerDelegate) {
 	b.isProposerFn = f
-}
-
-func (b *mockBackendBuilder) withBuildProposalFn(f buildProposalDelegate) {
-	b.buildProposalFn = f
 }
 
 func (b *mockBackendBuilder) withBuildPrePrepareMessageFn(f buildPrePrepareMessageDelegate) {
@@ -420,7 +415,7 @@ func (b *mockBackendBuilder) withBuildRoundChangeMessageFn(f buildRoundChangeMes
 	b.buildRoundChangeMessageFn = f
 }
 
-func (b *mockBackendBuilder) withIdFn(f idDelegate) {
+func (b *mockBackendBuilder) withIDFn(f idDelegate) {
 	b.idFn = f
 }
 

--- a/core/byzantine_test.go
+++ b/core/byzantine_test.go
@@ -20,10 +20,10 @@ func TestByzantineBehaviour(t *testing.T) {
 		cluster := newCluster(
 			6,
 			func(c *cluster) {
-				for id, node := range c.nodes {
+				for _, node := range c.nodes {
 					currentNode := node
 					node.core = NewIBFT(
-						testingLogger(id),
+						mockLogger{},
 						&mockBackend{
 							isValidBlockFn:         isValidProposal,
 							isValidProposalHashFn:  isValidProposalHash,
@@ -50,6 +50,7 @@ func TestByzantineBehaviour(t *testing.T) {
 								if currentNode.byzantine {
 									proposalHash = []byte("invalid proposal hash")
 								}
+
 								return buildBasicPreprepareMessage(
 									proposal,
 									proposalHash,
@@ -87,10 +88,10 @@ func TestByzantineBehaviour(t *testing.T) {
 		cluster := newCluster(
 			6,
 			func(c *cluster) {
-				for id, node := range c.nodes {
+				for _, node := range c.nodes {
 					currentNode := node
 					node.core = NewIBFT(
-						testingLogger(id),
+						mockLogger{},
 						&mockBackend{
 							isValidBlockFn:         isValidProposal,
 							isValidProposalHashFn:  isValidProposalHash,
@@ -107,6 +108,7 @@ func TestByzantineBehaviour(t *testing.T) {
 								if currentNode.byzantine {
 									proposalHash = []byte("invalid proposal hash")
 								}
+
 								return buildBasicPrepareMessage(
 									proposalHash,
 									currentNode.address,
@@ -141,10 +143,10 @@ func TestByzantineBehaviour(t *testing.T) {
 		cluster := newCluster(
 			6,
 			func(c *cluster) {
-				for id, node := range c.nodes {
+				for _, node := range c.nodes {
 					currentNode := node
 					node.core = NewIBFT(
-						testingLogger(id),
+						mockLogger{},
 						&mockBackend{
 							isValidBlockFn:         isValidProposal,
 							isValidProposalHashFn:  isValidProposalHash,
@@ -174,6 +176,7 @@ func TestByzantineBehaviour(t *testing.T) {
 								if currentNode.byzantine {
 									view.Round = uint64(rand.Int())
 								}
+
 								return buildBasicPreprepareMessage(
 									proposal,
 									validProposalHash,
@@ -212,10 +215,10 @@ func TestByzantineBehaviour(t *testing.T) {
 		cluster := newCluster(
 			6,
 			func(c *cluster) {
-				for id, node := range c.nodes {
+				for _, node := range c.nodes {
 					currentNode := node
 					node.core = NewIBFT(
-						testingLogger(id),
+						mockLogger{},
 						&mockBackend{
 							isValidBlockFn:         isValidProposal,
 							isValidProposalHashFn:  isValidProposalHash,
@@ -277,10 +280,10 @@ func TestByzantineBehaviour(t *testing.T) {
 		cluster := newCluster(
 			6,
 			func(c *cluster) {
-				for id, node := range c.nodes {
+				for _, node := range c.nodes {
 					currentNode := node
 					node.core = NewIBFT(
-						testingLogger(id),
+						mockLogger{},
 						&mockBackend{
 							isValidBlockFn:         isValidProposal,
 							isValidProposalHashFn:  isValidProposalHash,
@@ -309,6 +312,7 @@ func TestByzantineBehaviour(t *testing.T) {
 								if currentNode.byzantine {
 									view.Round = uint64(rand.Int())
 								}
+
 								return buildBasicPreprepareMessage(
 									proposal,
 									validProposalHash,
@@ -359,10 +363,10 @@ func TestByzantineBehaviour(t *testing.T) {
 		cluster := newCluster(
 			6,
 			func(c *cluster) {
-				for id, node := range c.nodes {
+				for _, node := range c.nodes {
 					currentNode := node
 					node.core = NewIBFT(
-						testingLogger(id),
+						mockLogger{},
 						&mockBackend{
 							isValidBlockFn:         isValidProposal,
 							isValidProposalHashFn:  isValidProposalHash,
@@ -388,6 +392,7 @@ func TestByzantineBehaviour(t *testing.T) {
 								if currentNode.byzantine {
 									proposalHash = []byte("invalid proposal hash")
 								}
+
 								return buildBasicPreprepareMessage(
 									proposal,
 									proposalHash,
@@ -438,10 +443,10 @@ func TestByzantineBehaviour(t *testing.T) {
 		cluster := newCluster(
 			6,
 			func(c *cluster) {
-				for id, node := range c.nodes {
+				for _, node := range c.nodes {
 					currentNode := node
 					node.core = NewIBFT(
-						testingLogger(id),
+						mockLogger{},
 						&mockBackend{
 							isValidBlockFn:         isValidProposal,
 							isValidProposalHashFn:  isValidProposalHash,
@@ -466,6 +471,7 @@ func TestByzantineBehaviour(t *testing.T) {
 								if currentNode.byzantine {
 									proposalHash = []byte("invalid proposal hash")
 								}
+
 								return buildBasicPrepareMessage(
 									proposalHash,
 									currentNode.address,
@@ -513,10 +519,10 @@ func TestByzantineBehaviour(t *testing.T) {
 		cluster := newCluster(
 			6,
 			func(c *cluster) {
-				for id, node := range c.nodes {
+				for _, node := range c.nodes {
 					currentNode := node
 					node.core = NewIBFT(
-						testingLogger(id),
+						mockLogger{},
 						&mockBackend{
 							isValidBlockFn:         isValidProposal,
 							isValidProposalHashFn:  isValidProposalHash,
@@ -542,6 +548,7 @@ func TestByzantineBehaviour(t *testing.T) {
 								if currentNode.byzantine {
 									committedSeal = []byte("invalid committed seal")
 								}
+
 								return buildBasicCommitMessage(
 									validProposalHash,
 									committedSeal,
@@ -582,18 +589,4 @@ func TestByzantineBehaviour(t *testing.T) {
 		assert.NoError(t, cluster.progressToHeight(30*time.Second, 2))
 		assert.Equal(t, uint64(2), cluster.latestHeight)
 	})
-}
-
-func testingLogger(nodeId int) *mockLogger {
-	return &mockLogger{
-		infoFn: func(s string, _ ...interface{}) {
-			fmt.Printf("[Node %d]: %s\n", nodeId, s)
-		},
-		debugFn: func(s string, _ ...interface{}) {
-			fmt.Printf("[Node %d]: %s\n", nodeId, s)
-		},
-		errorFn: func(s string, _ ...interface{}) {
-			fmt.Printf("[Node %d]: %s\n", nodeId, s)
-		},
-	}
 }

--- a/core/byzantine_test.go
+++ b/core/byzantine_test.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"bytes"
-	"fmt"
 	"github.com/0xPolygon/go-ibft/messages/proto"
 	"math/rand"
 	"testing"
@@ -171,8 +170,6 @@ func TestByzantineBehaviour(t *testing.T) {
 								certificate *proto.RoundChangeCertificate,
 								view *proto.View,
 							) *proto.Message {
-								fmt.Println(currentNode.address)
-								currentNode.core.log.Debug(fmt.Sprint("TERE ", view, currentNode.byzantine))
 								if currentNode.byzantine {
 									view.Round = uint64(rand.Int())
 								}
@@ -307,8 +304,6 @@ func TestByzantineBehaviour(t *testing.T) {
 								certificate *proto.RoundChangeCertificate,
 								view *proto.View,
 							) *proto.Message {
-								fmt.Println(currentNode.address)
-								currentNode.core.log.Debug(fmt.Sprint("TERE ", view, currentNode.byzantine))
 								if currentNode.byzantine {
 									view.Round = uint64(rand.Int())
 								}

--- a/core/helpers_test.go
+++ b/core/helpers_test.go
@@ -37,9 +37,10 @@ func isValidProposalHash(proposal, proposalHash []byte) bool {
 }
 
 type node struct {
-	core    *IBFT
-	address []byte
-	offline bool
+	core      *IBFT
+	address   []byte
+	offline   bool
+	byzantine bool
 }
 
 func (n *node) addr() []byte {
@@ -215,6 +216,12 @@ func (c *cluster) gossip(msg *proto.Message) {
 
 func (c *cluster) maxFaulty() uint64 {
 	return (uint64(len(c.nodes)) - 1) / 3
+}
+
+func (c *cluster) makeNByzantine(num int) {
+	for i := 0; i < num; i++ {
+		c.nodes[i].byzantine = true
+	}
 }
 
 func (c *cluster) stopN(num int) {


### PR DESCRIPTION
# Description

As per auditors suggestions within **_Suggestion 5: Add Tests for Byzantine Behavior_** that states:

> We recommend writing test cases for when a certain number of validators breaks all assumptions on honest behavior. Such test cases would require randomization on the data sent in all stages. This could be achieved by choosing, for example, randomized round numbers in RCCs and randomized content (round number, hashes, commit seals, Prepared-Certificates, etc.) in PRE-PREPARE, PREPARE, COMMIT, and ROUND_CHANGE messages.

Here is non randomized content but a step in right direction. Tests written to target specific scenarios that target most vulnerable parts of our code. 

Decision for making these tests not randomized:
- Because of the argument that malicious nodes have higher chance in succeeding if they all strive to reach the same effect.
- Time constraint

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have added sufficient documentation in code
