### PR TITLE
Suggestion 4: Add Fault Tests 

### DIFF
--- a/core/drop_test.go
+++ b/core/drop_test.go
@@ -63,22 +63,22 @@ func TestDropAllAndRecover(t *testing.T) {
 	err := cluster.progressToHeight(5*time.Second, 1)
 	assert.NoError(t, err, "unable to reach height: %w", err)
 	assert.Equal(t, uint64(1), cluster.latestHeight)
-	assertValidInsertedBlocks(insertedBlocks, t) // Make sure the inserted blocks are valid
+	assertValidInsertedBlocks(t, insertedBlocks) // Make sure the inserted blocks are valid
 
 	insertedBlocks = make([][]byte, numNodes) // Purge
 
 	// Stop all nodes and make sure no blocks are written
 	cluster.stopN(len(cluster.nodes))
 	cluster.progressToHeight(5*time.Second, 2)
-	assertNInsertedBlocks(0, insertedBlocks, t)
+	assertNInsertedBlocks(t, 0, insertedBlocks)
 
 	// Start all and expect valid blocks to be written again
 	cluster.startN(len(cluster.nodes))
 	cluster.progressToHeight(5*time.Second, 10)
-	assertValidInsertedBlocks(insertedBlocks, t) // Make sure the inserted blocks are valid
+	assertValidInsertedBlocks(t, insertedBlocks) // Make sure the inserted blocks are valid
 }
 
-func assertNInsertedBlocks(n int, blocks [][]byte, t *testing.T) {
+func assertNInsertedBlocks(t *testing.T, n int, blocks [][]byte) {
 	t.Helper()
 
 	writtenBlocks := 0
@@ -91,7 +91,7 @@ func assertNInsertedBlocks(n int, blocks [][]byte, t *testing.T) {
 	assert.True(t, n == writtenBlocks)
 }
 
-func assertValidInsertedBlocks(blocks [][]byte, t *testing.T) {
+func assertValidInsertedBlocks(t *testing.T, blocks [][]byte) {
 	t.Helper()
 
 	for _, block := range blocks {

--- a/core/drop_test.go
+++ b/core/drop_test.go
@@ -1,19 +1,222 @@
 package core
 
 import (
+	"bytes"
+	"github.com/0xPolygon/go-ibft/messages"
+	"github.com/0xPolygon/go-ibft/messages/proto"
+	"math/rand"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
+func TestDropAllAndRecover(t *testing.T) {
+	t.Parallel()
+
+	var (
+		numNodes       = uint64(6)
+		insertedBlocks = make([][]byte, numNodes)
+	)
+
+	cluster := newCluster(
+		numNodes,
+		func(c *cluster) {
+			for nodeIndex, node := range c.nodes {
+				i := nodeIndex
+				currentNode := node
+				node.core = NewIBFT(
+					mockLogger{},
+					&mockBackend{
+						isValidBlockFn:         isValidProposal,
+						isValidProposalHashFn:  isValidProposalHash,
+						isValidSenderFn:        nil,
+						isValidCommittedSealFn: nil,
+						isProposerFn:           c.isProposer,
+
+						idFn: node.addr,
+
+						buildProposalFn:           buildValidProposal,
+						buildPrePrepareMessageFn:  node.buildPrePrepare,
+						buildPrepareMessageFn:     node.buildPrepare,
+						buildCommitMessageFn:      node.buildCommit,
+						buildRoundChangeMessageFn: node.buildRoundChange,
+
+						insertBlockFn: func(proposal []byte, _ []*messages.CommittedSeal) {
+							insertedBlocks[i] = proposal
+						},
+						hasQuorumFn: c.hasQuorumFn,
+					},
+					&mockTransport{multicastFn: func(message *proto.Message) {
+						if currentNode.offline {
+							return
+						}
+
+						c.gossip(message)
+					}},
+				)
+			}
+		},
+	)
+
+	// Progress the chain to claim it works ok by default
+	err := cluster.progressToHeight(5*time.Second, 1)
+	assert.NoError(t, err, "unable to reach height: %w", err)
+	assert.Equal(t, uint64(1), cluster.latestHeight)
+	assertValidInsertedBlocks(insertedBlocks, t) // Make sure the inserted blocks are valid
+
+	insertedBlocks = make([][]byte, numNodes) // Purge
+
+	// Stop all nodes and make sure no blocks are written
+	cluster.stopN(len(cluster.nodes))
+	cluster.progressToHeight(2*time.Second, 2)
+	assertNoInsertedBlocks(insertedBlocks, t)
+
+	// Start all and expect valid blocks to be written again
+	cluster.startN(len(cluster.nodes))
+	cluster.progressToHeight(5*time.Second, 10)
+	assertValidInsertedBlocks(insertedBlocks, t) // Make sure the inserted blocks are valid
+}
+
+func assertNoInsertedBlocks(blocks [][]byte, t *testing.T) {
+	t.Helper()
+
+	assertNInsertedBlocks(0, blocks, t)
+}
+
+func assertNInsertedBlocks(n int, blocks [][]byte, t *testing.T) {
+	t.Helper()
+
+	writtenBlocks := 0
+	for _, block := range blocks {
+		if !bytes.Equal(block, nil) {
+			writtenBlocks++
+		}
+	}
+
+	assert.True(t, n == writtenBlocks)
+}
+
+func assertValidInsertedBlocks(blocks [][]byte, t *testing.T) {
+	t.Helper()
+
+	for _, block := range blocks {
+		assert.True(t, bytes.Equal(block, validProposal))
+	}
+}
+
+func TestMaxFaultyPlusOneDroppingMessages(t *testing.T) {
+	t.Parallel()
+
+	cluster := newCluster(
+		6,
+		func(c *cluster) {
+			for _, node := range c.nodes {
+				currentNode := node
+				node.core = NewIBFT(
+					mockLogger{},
+					&mockBackend{
+						isValidBlockFn:         isValidProposal,
+						isValidProposalHashFn:  isValidProposalHash,
+						isValidSenderFn:        nil,
+						isValidCommittedSealFn: nil,
+						isProposerFn:           c.isProposer,
+
+						idFn: node.addr,
+
+						buildProposalFn:           buildValidProposal,
+						buildPrePrepareMessageFn:  node.buildPrePrepare,
+						buildPrepareMessageFn:     node.buildPrepare,
+						buildCommitMessageFn:      node.buildCommit,
+						buildRoundChangeMessageFn: node.buildRoundChange,
+
+						insertBlockFn: nil,
+						hasQuorumFn:   c.hasQuorumFn,
+					},
+					&mockTransport{multicastFn: func(message *proto.Message) {
+						if currentNode.faulty && rand.Intn(100) < 50 {
+							return
+						}
+
+						c.gossip(message)
+					}},
+				)
+			}
+		},
+	)
+
+	cluster.makeNFaulty(int(cluster.maxFaulty()))
+	assert.NoError(t, cluster.progressToHeight(40*time.Second, 10))
+	assert.Equal(t, uint64(10), cluster.latestHeight)
+}
+
+func TestAllFailAndGraduallyRecover(t *testing.T) {
+	t.Parallel()
+
+	var (
+		numNodes       = uint64(6)
+		insertedBlocks = make([][]byte, numNodes)
+	)
+
+	cluster := newCluster(
+		numNodes,
+		func(c *cluster) {
+			for nodeIndex, node := range c.nodes {
+				nodeIndex := nodeIndex
+				currentNode := node
+				node.core = NewIBFT(
+					mockLogger{},
+					&mockBackend{
+						isValidBlockFn:         isValidProposal,
+						isValidProposalHashFn:  isValidProposalHash,
+						isValidSenderFn:        nil,
+						isValidCommittedSealFn: nil,
+						isProposerFn:           c.isProposer,
+
+						idFn: node.addr,
+
+						buildProposalFn:           buildValidProposal,
+						buildPrePrepareMessageFn:  node.buildPrePrepare,
+						buildPrepareMessageFn:     node.buildPrepare,
+						buildCommitMessageFn:      node.buildCommit,
+						buildRoundChangeMessageFn: node.buildRoundChange,
+
+						insertBlockFn: func(proposal []byte, _ []*messages.CommittedSeal) {
+							insertedBlocks[nodeIndex] = proposal
+						},
+						hasQuorumFn: c.hasQuorumFn,
+					},
+					&mockTransport{multicastFn: func(msg *proto.Message) {
+						if !currentNode.offline {
+							for _, node := range c.nodes {
+								node.core.AddMessage(msg)
+							}
+						}
+					}},
+				)
+			}
+		},
+	)
+
+	// Start the main run loops
+	cluster.runGradualSequence(1, 10*time.Second)
+
+	// Wait until the main run loops finish
+	cluster.wg.Wait()
+
+	// Make sure the inserted blocks match what node 0 proposed
+	for _, block := range insertedBlocks {
+		assert.True(t, bytes.Equal(block, validProposal))
+	}
+}
+
 /*
-	Scenario:
-	1. Cluster can reach height 5
-	2. Stop MaxFaulty+1 nodes
-	3. Cluster cannot reach height 10
-	4. Start MaxFaulty+1 nodes
-	5. Cluster can reach height 10
+Scenario:
+1. Cluster can reach height 5
+2. Stop MaxFaulty+1 nodes
+3. Cluster cannot reach height 10
+4. Start MaxFaulty+1 nodes
+5. Cluster can reach height 10
 */
 func TestDropMaxFaultyPlusOne(t *testing.T) {
 	t.Parallel()
@@ -68,10 +271,10 @@ func TestDropMaxFaultyPlusOne(t *testing.T) {
 }
 
 /*
-	Scenario:
-	1. Cluster can reach height 5
-	2. Stop MaxFaulty nodes
-	3. Cluster can still reach height 10
+Scenario:
+1. Cluster can reach height 5
+2. Stop MaxFaulty nodes
+3. Cluster can still reach height 10
 */
 func TestDropMaxFaulty(t *testing.T) {
 	t.Parallel()

--- a/core/helpers_test.go
+++ b/core/helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"math/rand"
 	"sync"
 	"time"
 
@@ -37,9 +38,10 @@ func isValidProposalHash(proposal, proposalHash []byte) bool {
 }
 
 type node struct {
-	core    *IBFT
-	address []byte
-	offline bool
+	core      *IBFT
+	address   []byte
+	offline   bool
+	faulty    bool
 }
 
 func (n *node) addr() []byte {
@@ -130,6 +132,27 @@ func newCluster(num uint64, init func(*cluster)) *cluster {
 	return c
 }
 
+func (c *cluster) runGradualSequence(height uint64, timeout time.Duration) {
+	ctx, _ := context.WithTimeout(context.Background(), timeout)
+
+	for nodeIndex, n := range c.nodes {
+		c.wg.Add(1)
+
+		go func(ctx context.Context, ordinal int, node *node) {
+			// Start the main run loop for the node
+			runDelay := ordinal * rand.Intn(1000)
+
+			select {
+			case <-ctx.Done():
+			case <-time.After(time.Duration(runDelay) * time.Millisecond):
+				node.core.RunSequence(ctx, height)
+			}
+
+			c.wg.Done()
+		}(ctx, nodeIndex+1, n)
+	}
+}
+
 func (c *cluster) runSequence(ctx context.Context, height uint64) <-chan struct{} {
 	done := make(chan struct{})
 
@@ -215,6 +238,12 @@ func (c *cluster) gossip(msg *proto.Message) {
 
 func (c *cluster) maxFaulty() uint64 {
 	return (uint64(len(c.nodes)) - 1) / 3
+}
+
+func (c *cluster) makeNFaulty(num int) {
+	for i := 0; i < num; i++ {
+		c.nodes[i].faulty = true
+	}
 }
 
 func (c *cluster) stopN(num int) {


### PR DESCRIPTION
# Description

Quoting auditors report:
> - f validators were not started;  
> - f validators are up but not connected to the network; 
> - f validators crash simultaneously and then recover; 
> - f validators crash at different times and then recover one by one at random times;
> - f validators crash and recover after a significant delay (e.g., after 10 minutes); and
> - f validators drop every second message (message loss is 50%).

1. Validators not started are implicitly tested with a `TestDropMaxFaulty.` We don't discriminate between hights of the sequence ran because it is not in the scope of go-ibft to sync missing blocks.
2. This test is very relevant when testing by using orchestrated environment. In drop tests there is no difference between _not started_ and _not connected_.
3. and 4. are dealt with implementing number `TestAllFailAndGraduallyRecover` as it is a more difficult scenario for the network to deal with.
5. This kind of test will heavily impact our CI/CD process and should definitely be implemented in separate effort. Maybe where this tests are written to run on actually test cluster.
6. This test is covered with `TestMaxFaultyPlusOneDroppingMessages`


# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have added sufficient documentation in code
