### PR TITLE
Provide `View` instance to `BuildProposal`

### DIFF
--- a/core/backend.go
+++ b/core/backend.go
@@ -25,7 +25,7 @@ type MessageConstructor interface {
 	BuildCommitMessage(proposalHash []byte, view *proto.View) *proto.Message
 
 	// BuildRoundChangeMessage builds a ROUND_CHANGE message based on the passed in view,
-	// latest prepared proposed block, and latest prepared certificate
+	// latest prepared proposal, and latest prepared certificate
 	BuildRoundChangeMessage(
 		proposal *proto.Proposal,
 		certificate *proto.PreparedCertificate,
@@ -35,7 +35,7 @@ type MessageConstructor interface {
 
 // Verifier defines the verifier interface
 type Verifier interface {
-	// IsValidProposal if the proposal is valid
+	// IsValidProposal checks if the proposal is valid
 	IsValidProposal(rawProposal []byte) bool
 
 	// IsValidValidator checks if a signature in message is signed by sender
@@ -61,8 +61,8 @@ type Backend interface {
 	MessageConstructor
 	Verifier
 
-	// BuildProposal builds a new proposal for the height
-	BuildProposal(height uint64) []byte
+	// BuildProposal builds a new proposal for the given view (height and round)
+	BuildProposal(view *proto.View) []byte
 
 	// InsertProposal inserts a proposal with the specified committed seals
 	// the reason why we are including round here is because a single committedSeal

--- a/core/ibft.go
+++ b/core/ibft.go
@@ -975,7 +975,11 @@ func (i *IBFT) buildProposal(ctx context.Context, view *proto.View) *proto.Messa
 	)
 
 	if round == 0 {
-		rawProposal := i.backend.BuildProposal(height)
+		rawProposal := i.backend.BuildProposal(
+			&proto.View{
+				Height: height,
+				Round:  round,
+			})
 
 		return i.backend.BuildPrePrepareMessage(
 			rawProposal,
@@ -1026,7 +1030,11 @@ func (i *IBFT) buildProposal(ctx context.Context, view *proto.View) *proto.Messa
 
 	if previousProposal == nil {
 		//	build new proposal
-		proposal := i.backend.BuildProposal(height)
+		proposal := i.backend.BuildProposal(
+			&proto.View{
+				Height: height,
+				Round:  round,
+			})
 
 		return i.backend.BuildPrePrepareMessage(
 			proposal,

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -120,9 +120,9 @@ func (m mockBackend) IsProposer(id []byte, sequence, round uint64) bool {
 	return false
 }
 
-func (m mockBackend) BuildProposal(height uint64) []byte {
+func (m mockBackend) BuildProposal(view *proto.View) []byte {
 	if m.buildProposalFn != nil {
-		return m.buildProposalFn(height)
+		return m.buildProposalFn(view.Height)
 	}
 
 	return nil


### PR DESCRIPTION
# Description

This PR changes the `BuildProposal` function signature, by providing a view instance instead of only block height. This is done, because of polybft consensus protocol, which needs to track the current round when building a proposal (round number represents consensus data, and therefore such information is needed before building a proposal).

FTR:
This change was already made through PR #43 , but was removed through PR #55 

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [x] I have added sufficient documentation in code