### PR TITLE
Fix minor audit issues

### DIFF
--- a/core/ibft.go
+++ b/core/ibft.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"math"
@@ -662,9 +661,8 @@ func (i *IBFT) validateProposal(msg *proto.Message, view *proto.View) bool {
 		height = view.Height
 		round  = view.Round
 
-		proposal     = messages.ExtractProposal(msg)
-		proposalHash = messages.ExtractProposalHash(msg)
-		rcc          = messages.ExtractRoundChangeCertificate(msg)
+		proposal = messages.ExtractProposal(msg)
+		rcc      = messages.ExtractRoundChangeCertificate(msg)
 	)
 
 	// Make sure common proposal validations pass
@@ -755,7 +753,14 @@ func (i *IBFT) validateProposal(msg *proto.Message, view *proto.View) bool {
 		}
 	}
 
-	return bytes.Equal(expectedHash, proposalHash)
+	// Make sure hash of (EB, maxR) matches expected hash
+	return i.backend.IsValidProposalHash(
+		&proto.Proposal{
+			RawProposal: proposal.RawProposal,
+			Round:       maxRound,
+		},
+		expectedHash,
+	)
 }
 
 // handlePrePrepare parses the received proposal and performs

--- a/core/ibft.go
+++ b/core/ibft.go
@@ -722,15 +722,14 @@ func (i *IBFT) validateProposal(msg *proto.Message, view *proto.View) bool {
 	roundsAndPreparedBlockHashes := make([]roundHashTuple, 0)
 
 	for _, rcMessage := range rcc.RoundChangeMessages {
-		pc := messages.ExtractLatestPC(rcMessage)
+		cert := messages.ExtractLatestPC(rcMessage)
 
 		// Check if there is a certificate, and if it's a valid PC
-		if pc != nil && i.validPC(pc, proposal.Round, height) {
-			proposal := messages.ExtractProposal(pc.ProposalMessage)
-			hash := messages.ExtractProposalHash(pc.ProposalMessage)
+		if cert != nil && i.validPC(cert, msg.View.Round, height) {
+			hash := messages.ExtractProposalHash(cert.ProposalMessage)
 
 			roundsAndPreparedBlockHashes = append(roundsAndPreparedBlockHashes, roundHashTuple{
-				round: proposal.Round,
+				round: cert.ProposalMessage.View.Round,
 				hash:  hash,
 			})
 		}

--- a/core/ibft_test.go
+++ b/core/ibft_test.go
@@ -2274,7 +2274,7 @@ func TestIBFT_ValidateProposal(t *testing.T) {
 		assert.False(t, i.validateProposal(proposal, baseView))
 	})
 
-	t.Run("current node should not be the proposer", func(t *testing.T) {
+	t.Run("sender is not the correct proposer", func(t *testing.T) {
 		t.Parallel()
 
 		var (
@@ -2317,6 +2317,7 @@ func TestIBFT_ValidateProposal(t *testing.T) {
 		assert.False(t, i.validateProposal(proposal, baseView))
 	})
 
+	//nolint:dupl
 	t.Run("round is not correct", func(t *testing.T) {
 		t.Parallel()
 
@@ -2365,6 +2366,460 @@ func TestIBFT_ValidateProposal(t *testing.T) {
 		}
 
 		assert.False(t, i.validateProposal(proposal, baseView))
+	})
+
+	//nolint:dupl
+	t.Run("round is not correct", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			quorum     = uint64(4)
+			round      = uint64(1)
+			id         = []byte("node id")
+			uniqueNode = []byte("unique node")
+
+			log     = mockLogger{}
+			backend = mockBackend{
+				idFn: func() []byte {
+					return id
+				},
+				isProposerFn: func(proposer []byte, _ uint64, _ uint64) bool {
+					if bytes.Equal(proposer, uniqueNode) {
+						return true
+					}
+
+					return bytes.Equal(proposer, id)
+				},
+			}
+			transport = mockTransport{}
+		)
+
+		i := NewIBFT(log, backend, transport)
+
+		baseView := &proto.View{
+			Height: 0,
+			Round:  round,
+		}
+		proposal := &proto.Message{
+			View: baseView,
+			From: uniqueNode,
+			Type: proto.MessageType_PREPREPARE,
+			Payload: &proto.Message_PreprepareData{
+				PreprepareData: &proto.PrePrepareMessage{
+					Certificate: &proto.RoundChangeCertificate{
+						RoundChangeMessages: generateMessages(quorum, proto.MessageType_ROUND_CHANGE),
+					},
+					Proposal: &proto.Proposal{
+						Round: 0,
+					},
+				},
+			},
+		}
+
+		assert.False(t, i.validateProposal(proposal, baseView))
+	})
+
+	t.Run("A message in RoundChangeCertificate is not ROUND-CHANGE message", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			quorum     = uint64(4)
+			round      = uint64(1)
+			id         = []byte("node id")
+			uniqueNode = []byte("unique node")
+
+			log     = mockLogger{}
+			backend = mockBackend{
+				idFn: func() []byte {
+					return id
+				},
+				isProposerFn: func(proposer []byte, _ uint64, _ uint64) bool {
+					return bytes.Equal(proposer, uniqueNode)
+				},
+			}
+			transport = mockTransport{}
+		)
+
+		i := NewIBFT(log, backend, transport)
+
+		// 4 ROUND-CHANGE messages + 1 COMMIT message (wrong type message)
+		roundChangeMessages := make([]*proto.Message, 0)
+
+		for idx := 0; idx < int(quorum); idx++ {
+			roundChangeMessages = append(roundChangeMessages, &proto.Message{
+				From: []byte(fmt.Sprintf("node%d", idx)),
+				View: &proto.View{
+					Height: 0,
+					Round:  round,
+				},
+				Type:    proto.MessageType_ROUND_CHANGE,
+				Payload: &proto.Message_RoundChangeData{},
+			})
+		}
+
+		roundChangeMessages = append(roundChangeMessages, &proto.Message{
+			From: []byte(fmt.Sprintf("node%d", quorum)),
+			View: &proto.View{
+				Height: 0,
+				Round:  0,
+			},
+			Type:    proto.MessageType_COMMIT,
+			Payload: &proto.Message_RoundChangeData{},
+		})
+
+		baseView := &proto.View{
+			Height: 0,
+			Round:  round,
+		}
+		proposal := &proto.Message{
+			View: baseView,
+			From: uniqueNode,
+			Type: proto.MessageType_PREPREPARE,
+			Payload: &proto.Message_PreprepareData{
+				PreprepareData: &proto.PrePrepareMessage{
+					Certificate: &proto.RoundChangeCertificate{
+						RoundChangeMessages: roundChangeMessages,
+					},
+					Proposal: &proto.Proposal{
+						Round: round,
+					},
+				},
+			},
+		}
+
+		assert.False(t, i.validateProposal(proposal, baseView))
+	})
+
+	t.Run("A messages in RoundChangeCertificate has wrong height", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			quorum     = uint64(4)
+			round      = uint64(1)
+			id         = []byte("node id")
+			uniqueNode = []byte("unique node")
+
+			log     = mockLogger{}
+			backend = mockBackend{
+				idFn: func() []byte {
+					return id
+				},
+				isProposerFn: func(proposer []byte, _ uint64, _ uint64) bool {
+					return bytes.Equal(proposer, uniqueNode)
+				},
+			}
+			transport = mockTransport{}
+		)
+
+		i := NewIBFT(log, backend, transport)
+
+		// 4 ROUND-CHANGE messages
+		roundChangeMessages := make([]*proto.Message, quorum)
+
+		for idx := range roundChangeMessages {
+			roundChangeMessages[idx] = &proto.Message{
+				From: []byte(fmt.Sprintf("node%d", idx)),
+				View: &proto.View{
+					Height: 100, // wrong height
+					Round:  round,
+				},
+				Type:    proto.MessageType_ROUND_CHANGE,
+				Payload: &proto.Message_RoundChangeData{},
+			}
+		}
+
+		baseView := &proto.View{
+			Height: 0,
+			Round:  round,
+		}
+		proposal := &proto.Message{
+			View: baseView,
+			From: uniqueNode,
+			Type: proto.MessageType_PREPREPARE,
+			Payload: &proto.Message_PreprepareData{
+				PreprepareData: &proto.PrePrepareMessage{
+					Certificate: &proto.RoundChangeCertificate{
+						RoundChangeMessages: roundChangeMessages,
+					},
+					Proposal: &proto.Proposal{
+						Round: round,
+					},
+				},
+			},
+		}
+
+		assert.False(t, i.validateProposal(proposal, baseView))
+	})
+
+	t.Run("A messages in RoundChangeCertificate has wrong round", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			quorum     = uint64(4)
+			round      = uint64(1)
+			id         = []byte("node id")
+			uniqueNode = []byte("unique node")
+
+			log     = mockLogger{}
+			backend = mockBackend{
+				idFn: func() []byte {
+					return id
+				},
+				isProposerFn: func(proposer []byte, _ uint64, _ uint64) bool {
+					return bytes.Equal(proposer, uniqueNode)
+				},
+			}
+			transport = mockTransport{}
+		)
+
+		i := NewIBFT(log, backend, transport)
+
+		// 4 ROUND-CHANGE messages with wrong round
+		roundChangeMessages := make([]*proto.Message, quorum)
+
+		for idx := range roundChangeMessages {
+			roundChangeMessages[idx] = &proto.Message{
+				From: []byte(fmt.Sprintf("node%d", idx)),
+				View: &proto.View{
+					Height: 0,
+					Round:  round + 1, // wrong round
+				},
+				Type:    proto.MessageType_ROUND_CHANGE,
+				Payload: &proto.Message_RoundChangeData{},
+			}
+		}
+
+		baseView := &proto.View{
+			Height: 0,
+			Round:  round,
+		}
+		proposal := &proto.Message{
+			View: baseView,
+			From: uniqueNode,
+			Type: proto.MessageType_PREPREPARE,
+			Payload: &proto.Message_PreprepareData{
+				PreprepareData: &proto.PrePrepareMessage{
+					Certificate: &proto.RoundChangeCertificate{
+						RoundChangeMessages: roundChangeMessages,
+					},
+					Proposal: &proto.Proposal{
+						Round: round,
+					},
+				},
+			},
+		}
+
+		assert.False(t, i.validateProposal(proposal, baseView))
+	})
+
+	t.Run("A messages in RoundChangeCertificate is created by non-validator", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			quorum       = uint64(4)
+			round        = uint64(1)
+			id           = []byte("node id")
+			uniqueNode   = []byte("unique node")
+			nonValidator = []byte("non validator")
+
+			log     = mockLogger{}
+			backend = mockBackend{
+				idFn: func() []byte {
+					return id
+				},
+				isProposerFn: func(proposer []byte, _ uint64, _ uint64) bool {
+					return bytes.Equal(proposer, uniqueNode)
+				},
+				IsValidValidatorFn: func(m *proto.Message) bool {
+					return !bytes.Equal(m.From, nonValidator)
+				},
+			}
+			transport = mockTransport{}
+		)
+
+		i := NewIBFT(log, backend, transport)
+
+		// 4 ROUND-CHANGE messages by validators + 1 ROUND-CHANGE message by non-validator
+		roundChangeMessages := make([]*proto.Message, 0)
+
+		for idx := 0; idx < int(quorum); idx++ {
+			roundChangeMessages = append(roundChangeMessages, &proto.Message{
+				From: []byte(fmt.Sprintf("node%d", idx)),
+				View: &proto.View{
+					Height: 0,
+					Round:  round,
+				},
+				Type:    proto.MessageType_ROUND_CHANGE,
+				Payload: &proto.Message_RoundChangeData{},
+			})
+		}
+
+		roundChangeMessages = append(roundChangeMessages, &proto.Message{
+			From: nonValidator,
+			View: &proto.View{
+				Height: 0,
+				Round:  round,
+			},
+			Type:    proto.MessageType_ROUND_CHANGE,
+			Payload: &proto.Message_RoundChangeData{},
+		})
+
+		baseView := &proto.View{
+			Height: 0,
+			Round:  round,
+		}
+		proposal := &proto.Message{
+			View: baseView,
+			From: uniqueNode,
+			Type: proto.MessageType_PREPREPARE,
+			Payload: &proto.Message_PreprepareData{
+				PreprepareData: &proto.PrePrepareMessage{
+					Certificate: &proto.RoundChangeCertificate{
+						RoundChangeMessages: roundChangeMessages,
+					},
+					Proposal: &proto.Proposal{
+						Round: round,
+					},
+				},
+			},
+		}
+
+		assert.False(t, i.validateProposal(proposal, baseView))
+	})
+
+	t.Run("hash of (RawProposal, maxRound) doesn't equal to the hash in proposal message", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			quorum    = uint64(4)
+			round     = uint64(2)
+			id        = []byte("node id")
+			proposers = [][]byte{
+				[]byte("proposer 0"), // proposer for round 0
+				[]byte("proposer 1"), // proposer for round 1
+				[]byte("proposer 2"), // proposer for round 2
+			}
+
+			nonValidator = []byte("non validator")
+			rawProposal  = []byte("raw proposal")
+
+			hashFn = func(rawProposal []byte, round uint64) []byte {
+				return []byte(fmt.Sprintf("%s_%d", rawProposal, round))
+			}
+
+			correctProposalHash = hashFn(rawProposal, round)
+
+			log     = mockLogger{}
+			backend = mockBackend{
+				idFn: func() []byte {
+					return id
+				},
+				isProposerFn: func(proposer []byte, _ uint64, round uint64) bool {
+					return bytes.Equal(proposer, proposers[round])
+				},
+				IsValidValidatorFn: func(m *proto.Message) bool {
+					return !bytes.Equal(m.From, nonValidator)
+				},
+				isValidProposalHashFn: func(p *proto.Proposal, b []byte) bool {
+					return bytes.Equal(
+						b,
+						hashFn(p.RawProposal, p.Round),
+					)
+				},
+			}
+			transport = mockTransport{}
+
+			views = []*proto.View{
+				{
+					Height: 0,
+					Round:  round - 2,
+				},
+				// previous round
+				{
+					Height: 0,
+					Round:  round - 1,
+				},
+				// current round
+				{
+					Height: 0,
+					Round:  round,
+				},
+			}
+		)
+
+		i := NewIBFT(log, backend, transport)
+
+		// previous PREPREPARE + PREPARE messages whose proposal hashes are not correct
+		previousProposal := &proto.Message{
+			View: views[0],
+			From: proposers[0],
+			Type: proto.MessageType_PREPREPARE,
+			Payload: &proto.Message_PreprepareData{
+				PreprepareData: &proto.PrePrepareMessage{
+					// the hash should be (proposal, 0)
+					Proposal: &proto.Proposal{
+						Round:       round - 2,
+						RawProposal: rawProposal,
+					},
+					// the hash is created from (proposal, 2)
+					ProposalHash: correctProposalHash,
+				},
+			},
+		}
+
+		previousPrepares := make([]*proto.Message, quorum)
+		for idx := range previousPrepares {
+			previousPrepares[idx] = &proto.Message{
+				From: []byte(fmt.Sprintf("node%d", idx)),
+				View: views[0],
+				Type: proto.MessageType_PREPARE,
+				Payload: &proto.Message_PrepareData{
+					PrepareData: &proto.PrepareMessage{
+						ProposalHash: correctProposalHash,
+					},
+				},
+			}
+		}
+
+		// ROUND-CHANGE messages for round 2
+		roundChangeMessages := make([]*proto.Message, quorum)
+
+		for idx := range roundChangeMessages {
+			roundChangeMessages[idx] = &proto.Message{
+				From: []byte(fmt.Sprintf("node%d", idx)),
+				View: views[2],
+				Type: proto.MessageType_ROUND_CHANGE,
+				Payload: &proto.Message_RoundChangeData{
+					RoundChangeData: &proto.RoundChangeMessage{
+						LatestPreparedCertificate: &proto.PreparedCertificate{
+							ProposalMessage: previousProposal,
+							PrepareMessages: previousPrepares,
+						},
+					},
+				},
+			}
+		}
+
+		// proposal with RoundChangeCertificate
+		proposal := &proto.Message{
+			View: views[2],
+			From: proposers[2],
+			Type: proto.MessageType_PREPREPARE,
+			Payload: &proto.Message_PreprepareData{
+				PreprepareData: &proto.PrePrepareMessage{
+					Certificate: &proto.RoundChangeCertificate{
+						RoundChangeMessages: roundChangeMessages,
+					},
+					ProposalHash: hashFn(rawProposal, round),
+					Proposal: &proto.Proposal{
+						Round:       round,
+						RawProposal: rawProposal,
+					},
+				},
+			},
+		}
+
+		assert.False(t, i.validateProposal(proposal, views[2]))
 	})
 }
 


### PR DESCRIPTION
# Description

Fixes minor issues based on additional audit comments
1. `ValidateProposal` should check if `KEC(RawProposal, maxRound)` equals to hash in proposal of PreparedCertificate of RoundChange message
2. `BuildProposal` should use round in proposal round instead of proposal message's view round in order to find max round from PreparedCertificates

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [x] I have added sufficient documentation in code

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
