### PR TITLE
Evm-566: Move quorum function to go ibft

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
           submodules: recursive
 
       - name: Go test
-        run: go test -test.short -covermode=atomic -shuffle=on -coverprofile coverage.out -timeout 10m ./...
+        run: go test -test.short -covermode=atomic -shuffle=on -coverprofile coverage.out -timeout 15m ./...
 
       - name: Upload coverage file to Codecov
         uses: codecov/codecov-action@v3
@@ -45,7 +45,7 @@ jobs:
           submodules: recursive
 
       - name: Run Go Test with race
-        run: go test -test.short -race -shuffle=on -timeout 10m ./...
+        run: go test -test.short -race -shuffle=on -timeout 15m ./...
 
   reproducible-builds:
     runs-on: ubuntu-latest

--- a/core/backend.go
+++ b/core/backend.go
@@ -3,8 +3,6 @@
 package core
 
 import (
-	"math/big"
-
 	"github.com/0xPolygon/go-ibft/messages"
 	"github.com/0xPolygon/go-ibft/messages/proto"
 )
@@ -62,6 +60,7 @@ type Verifier interface {
 type Backend interface {
 	MessageConstructor
 	Verifier
+	ValidatorBackend
 
 	// BuildProposal builds a new proposal for the given view (height and round)
 	BuildProposal(view *proto.View) []byte
@@ -73,8 +72,4 @@ type Backend interface {
 
 	// ID returns the validator's ID
 	ID() []byte
-
-	// GetVotingPowers returns map of validators addresses and their voting powers
-	// for the specified height.
-	GetVotingPowers(height uint64) (map[string]*big.Int, error)
 }

--- a/core/backend.go
+++ b/core/backend.go
@@ -74,7 +74,7 @@ type Backend interface {
 	// ID returns the validator's ID
 	ID() []byte
 
-	// GetVotingPower returns map of validators addresses and their voting powers
+	// GetVotingPowers returns map of validators addresses and their voting powers
 	// for the specified height.
-	GetVotingPower(height uint64) (map[string]*big.Int, error)
+	GetVotingPowers(height uint64) (map[string]*big.Int, error)
 }

--- a/core/backend.go
+++ b/core/backend.go
@@ -3,6 +3,8 @@
 package core
 
 import (
+	"math/big"
+
 	"github.com/0xPolygon/go-ibft/messages"
 	"github.com/0xPolygon/go-ibft/messages/proto"
 )
@@ -72,7 +74,7 @@ type Backend interface {
 	// ID returns the validator's ID
 	ID() []byte
 
-	// HasQuorum returns true if the quorum is reached
+	// GetVotingPower returns map of validators addresses and their voting powers
 	// for the specified height.
-	HasQuorum(height uint64, msgs []*proto.Message, msgType proto.MessageType) bool
+	GetVotingPower(height uint64) (map[string]*big.Int, error)
 }

--- a/core/byzantine_test.go
+++ b/core/byzantine_test.go
@@ -27,7 +27,7 @@ func TestByzantineBehaviour(t *testing.T) {
 					backendBuilder.withProposerFn(createForcedRCProposerFn(c))
 					backendBuilder.withIDFn(currentNode.addr)
 					backendBuilder.withBuildPrePrepareMessageFn(createBadHashPrePrepareMessageFn(currentNode))
-					backendBuilder.withHasQuorumFn(c.hasQuorumFn)
+					backendBuilder.withGetVotingPowerFn(testCommonGetVotingPowertFnForNodes(c.nodes))
 
 					node.core = NewIBFT(
 						mockLogger{},
@@ -60,7 +60,7 @@ func TestByzantineBehaviour(t *testing.T) {
 					backendBuilder.withProposerFn(c.isProposer)
 					backendBuilder.withIDFn(currentNode.addr)
 					backendBuilder.withBuildPrepareMessageFn(createBadHashPrepareMessageFn(currentNode))
-					backendBuilder.withHasQuorumFn(c.hasQuorumFn)
+					backendBuilder.withGetVotingPowerFn(testCommonGetVotingPowertFnForNodes(c.nodes))
 
 					node.core = NewIBFT(
 						mockLogger{},
@@ -94,7 +94,7 @@ func TestByzantineBehaviour(t *testing.T) {
 					backendBuilder.withProposerFn(createForcedRCProposerFn(c))
 					backendBuilder.withIDFn(currentNode.addr)
 					backendBuilder.withBuildPrePrepareMessageFn(createBadRoundPrePrepareMessageFn(currentNode))
-					backendBuilder.withHasQuorumFn(c.hasQuorumFn)
+					backendBuilder.withGetVotingPowerFn(testCommonGetVotingPowertFnForNodes(c.nodes))
 
 					node.core = NewIBFT(
 						mockLogger{},
@@ -129,7 +129,7 @@ func TestByzantineBehaviour(t *testing.T) {
 					backendBuilder.withProposerFn(createForcedRCProposerFn(c))
 					backendBuilder.withIDFn(currentNode.addr)
 					backendBuilder.withBuildRoundChangeMessageFn(createBadRoundRoundChangeFn(currentNode))
-					backendBuilder.withHasQuorumFn(c.hasQuorumFn)
+					backendBuilder.withGetVotingPowerFn(testCommonGetVotingPowertFnForNodes(c.nodes))
 
 					node.core = NewIBFT(
 						mockLogger{},
@@ -164,7 +164,7 @@ func TestByzantineBehaviour(t *testing.T) {
 					backendBuilder.withIDFn(currentNode.addr)
 					backendBuilder.withBuildPrePrepareMessageFn(createBadRoundPrePrepareMessageFn(currentNode))
 					backendBuilder.withBuildRoundChangeMessageFn(createBadRoundRoundChangeFn(currentNode))
-					backendBuilder.withHasQuorumFn(c.hasQuorumFn)
+					backendBuilder.withGetVotingPowerFn(testCommonGetVotingPowertFnForNodes(c.nodes))
 
 					node.core = NewIBFT(
 						mockLogger{},
@@ -199,7 +199,7 @@ func TestByzantineBehaviour(t *testing.T) {
 					backendBuilder.withIDFn(currentNode.addr)
 					backendBuilder.withBuildPrePrepareMessageFn(createBadHashPrePrepareMessageFn(currentNode))
 					backendBuilder.withBuildRoundChangeMessageFn(createBadRoundRoundChangeFn(currentNode))
-					backendBuilder.withHasQuorumFn(c.hasQuorumFn)
+					backendBuilder.withGetVotingPowerFn(testCommonGetVotingPowertFnForNodes(c.nodes))
 
 					node.core = NewIBFT(
 						mockLogger{},
@@ -234,7 +234,7 @@ func TestByzantineBehaviour(t *testing.T) {
 					backendBuilder.withIDFn(currentNode.addr)
 					backendBuilder.withBuildPrepareMessageFn(createBadHashPrepareMessageFn(currentNode))
 					backendBuilder.withBuildRoundChangeMessageFn(createBadRoundRoundChangeFn(currentNode))
-					backendBuilder.withHasQuorumFn(c.hasQuorumFn)
+					backendBuilder.withGetVotingPowerFn(testCommonGetVotingPowertFnForNodes(c.nodes))
 
 					node.core = NewIBFT(
 						mockLogger{},
@@ -269,7 +269,7 @@ func TestByzantineBehaviour(t *testing.T) {
 					backendBuilder.withIDFn(currentNode.addr)
 					backendBuilder.withBuildCommitMessageFn(createBadCommitMessageFn(currentNode))
 					backendBuilder.withBuildRoundChangeMessageFn(createBadRoundRoundChangeFn(currentNode))
-					backendBuilder.withHasQuorumFn(c.hasQuorumFn)
+					backendBuilder.withGetVotingPowerFn(testCommonGetVotingPowertFnForNodes(c.nodes))
 
 					node.core = NewIBFT(
 						mockLogger{},
@@ -400,7 +400,7 @@ type mockBackendBuilder struct {
 	buildCommitMessageFn      buildCommitMessageDelegate
 	buildRoundChangeMessageFn buildRoundChangeMessageDelegate
 
-	hasQuorumFn hasQuorumDelegate
+	getVotingPowerFn getVotingPowerDelegate
 }
 
 func (b *mockBackendBuilder) withProposerFn(f isProposerDelegate) {
@@ -427,8 +427,8 @@ func (b *mockBackendBuilder) withIDFn(f idDelegate) {
 	b.idFn = f
 }
 
-func (b *mockBackendBuilder) withHasQuorumFn(f hasQuorumDelegate) {
-	b.hasQuorumFn = f
+func (b *mockBackendBuilder) withGetVotingPowerFn(f getVotingPowerDelegate) {
+	b.getVotingPowerFn = f
 }
 
 func (b *mockBackendBuilder) build(node *node) *mockBackend {
@@ -462,6 +462,6 @@ func (b *mockBackendBuilder) build(node *node) *mockBackend {
 		buildCommitMessageFn:      b.buildCommitMessageFn,
 		buildRoundChangeMessageFn: b.buildRoundChangeMessageFn,
 		insertProposalFn:          nil,
-		hasQuorumFn:               b.hasQuorumFn,
+		getVotingPowerFn:          b.getVotingPowerFn,
 	}
 }

--- a/core/consensus_test.go
+++ b/core/consensus_test.go
@@ -124,23 +124,6 @@ func quorum(numNodes uint64) uint64 {
 	}
 }
 
-func commonHasQuorumFn(numNodes uint64) func(messages []*proto.Message, msgType proto.MessageType) bool {
-	quorum := quorum(numNodes)
-
-	return func(messages []*proto.Message, msgType proto.MessageType) bool {
-		switch msgType {
-		case proto.MessageType_PREPREPARE:
-			return len(messages) >= 0
-		case proto.MessageType_PREPARE:
-			return len(messages) >= int(quorum)-1
-		case proto.MessageType_ROUND_CHANGE, proto.MessageType_COMMIT:
-			return len(messages) >= int(quorum)
-		}
-
-		return false
-	}
-}
-
 // TestConsensus_ValidFlow tests the following scenario:
 // N = 4
 //
@@ -170,7 +153,7 @@ func TestConsensus_ValidFlow(t *testing.T) {
 	// for the Backend, for all nodes
 	commonBackendCallback := func(backend *mockBackend, nodeIndex int) {
 		// Make sure the quorum function requires all nodes
-		backend.hasQuorumFn = commonHasQuorumFn(numNodes)
+		backend.getVotingPowerFn = testCommonGetVotingPowertFn(nodes)
 
 		// Make sure the node ID is properly relayed
 		backend.idFn = func() []byte {
@@ -304,8 +287,8 @@ func TestConsensus_InvalidBlock(t *testing.T) {
 	// commonBackendCallback is the common method modification required
 	// for the Backend, for all nodes
 	commonBackendCallback := func(backend *mockBackend, nodeIndex int) {
-		// Make sure the quorum function is Quorum optimal
-		backend.hasQuorumFn = commonHasQuorumFn(numNodes)
+		// Make sure the quorum function requires all nodes
+		backend.getVotingPowerFn = testCommonGetVotingPowertFn(nodes)
 
 		// Make sure the node ID is properly relayed
 		backend.idFn = func() []byte {

--- a/core/consensus_test.go
+++ b/core/consensus_test.go
@@ -124,10 +124,10 @@ func quorum(numNodes uint64) uint64 {
 	}
 }
 
-func commonHasQuorumFn(numNodes uint64) func(height uint64, messages []*proto.Message, msgType proto.MessageType) bool {
+func commonHasQuorumFn(numNodes uint64) func(messages []*proto.Message, msgType proto.MessageType) bool {
 	quorum := quorum(numNodes)
 
-	return func(height uint64, messages []*proto.Message, msgType proto.MessageType) bool {
+	return func(messages []*proto.Message, msgType proto.MessageType) bool {
 		switch msgType {
 		case proto.MessageType_PREPREPARE:
 			return len(messages) >= 0

--- a/core/drop_test.go
+++ b/core/drop_test.go
@@ -47,7 +47,7 @@ func TestDropAllAndRecover(t *testing.T) {
 						insertProposalFn: func(proposal *proto.Proposal, _ []*messages.CommittedSeal) {
 							insertedBlocks[i] = proposal.RawProposal
 						},
-						hasQuorumFn: c.hasQuorumFn,
+						getVotingPowerFn: testCommonGetVotingPowertFnForNodes(c.nodes),
 					},
 					&mockTransport{multicastFn: func(message *proto.Message) {
 						if currentNode.offline {
@@ -128,7 +128,7 @@ func TestMaxFaultyDroppingMessages(t *testing.T) {
 						buildRoundChangeMessageFn: node.buildRoundChange,
 
 						insertProposalFn: nil,
-						hasQuorumFn:      c.hasQuorumFn,
+						getVotingPowerFn: testCommonGetVotingPowertFnForNodes(c.nodes),
 					},
 					&mockTransport{multicastFn: func(message *proto.Message) {
 						if currentNode.faulty && rand.Intn(100) < 50 {
@@ -181,7 +181,7 @@ func TestAllFailAndGraduallyRecover(t *testing.T) {
 						insertProposalFn: func(proposal *proto.Proposal, _ []*messages.CommittedSeal) {
 							insertedBlocks[nodeIndex] = proposal.RawProposal
 						},
-						hasQuorumFn: c.hasQuorumFn,
+						getVotingPowerFn: testCommonGetVotingPowertFnForNodes(c.nodes),
 					},
 					&mockTransport{multicastFn: func(msg *proto.Message) {
 						if !currentNode.offline {
@@ -246,7 +246,7 @@ func TestDropMaxFaultyPlusOne(t *testing.T) {
 						buildRoundChangeMessageFn: node.buildRoundChange,
 
 						insertProposalFn: nil,
-						hasQuorumFn:      c.hasQuorumFn,
+						getVotingPowerFn: testCommonGetVotingPowertFnForNodes(c.nodes),
 					},
 
 					&mockTransport{multicastFn: c.gossip},
@@ -304,7 +304,7 @@ func TestDropMaxFaulty(t *testing.T) {
 						buildRoundChangeMessageFn: node.buildRoundChange,
 
 						insertProposalFn: nil,
-						hasQuorumFn:      c.hasQuorumFn,
+						getVotingPowerFn: testCommonGetVotingPowertFnForNodes(c.nodes),
 					},
 
 					&mockTransport{multicastFn: c.gossip},

--- a/core/helpers_test.go
+++ b/core/helpers_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"math/big"
 	"math/rand"
 	"sync"
 	"time"
@@ -209,10 +211,6 @@ func (c *cluster) addresses() [][]byte {
 	return addresses
 }
 
-func (c *cluster) hasQuorumFn(messages []*proto.Message, msgType proto.MessageType) bool {
-	return commonHasQuorumFn(uint64(len(c.nodes)))(messages, msgType)
-}
-
 func (c *cluster) isProposer(
 	from []byte,
 	height,
@@ -257,5 +255,41 @@ func (c *cluster) stopN(num int) {
 func (c *cluster) startN(num int) {
 	for i := 0; i < num; i++ {
 		c.nodes[i].offline = false
+	}
+}
+
+func testCommonGetVotingPowertFn(nodes [][]byte) func(u uint64) (map[string]*big.Int, error) {
+	return func(u uint64) (map[string]*big.Int, error) {
+		result := map[string]*big.Int{}
+
+		for _, x := range nodes {
+			result[string(x)] = big.NewInt(1)
+		}
+
+		return result, nil
+	}
+}
+
+func testCommonGetVotingPowertFnForCnt(nodesCnt int) func(u uint64) (map[string]*big.Int, error) {
+	return func(u uint64) (map[string]*big.Int, error) {
+		result := map[string]*big.Int{}
+
+		for i := 0; i < nodesCnt; i++ {
+			result[fmt.Sprintf("%d", i)] = big.NewInt(1)
+		}
+
+		return result, nil
+	}
+}
+
+func testCommonGetVotingPowertFnForNodes(nodes []*node) func(u uint64) (map[string]*big.Int, error) {
+	return func(u uint64) (map[string]*big.Int, error) {
+		result := map[string]*big.Int{}
+
+		for _, x := range nodes {
+			result[string(x.address)] = big.NewInt(1)
+		}
+
+		return result, nil
 	}
 }

--- a/core/helpers_test.go
+++ b/core/helpers_test.go
@@ -209,8 +209,8 @@ func (c *cluster) addresses() [][]byte {
 	return addresses
 }
 
-func (c *cluster) hasQuorumFn(height uint64, messages []*proto.Message, msgType proto.MessageType) bool {
-	return commonHasQuorumFn(uint64(len(c.nodes)))(height, messages, msgType)
+func (c *cluster) hasQuorumFn(messages []*proto.Message, msgType proto.MessageType) bool {
+	return commonHasQuorumFn(uint64(len(c.nodes)))(messages, msgType)
 }
 
 func (c *cluster) isProposer(

--- a/core/helpers_test.go
+++ b/core/helpers_test.go
@@ -270,12 +270,12 @@ func testCommonGetVotingPowertFn(nodes [][]byte) func(u uint64) (map[string]*big
 	}
 }
 
-func testCommonGetVotingPowertFnForCnt(nodesCnt int) func(u uint64) (map[string]*big.Int, error) {
+func testCommonGetVotingPowertFnForCnt(nodesCnt uint64) func(u uint64) (map[string]*big.Int, error) {
 	return func(u uint64) (map[string]*big.Int, error) {
 		result := map[string]*big.Int{}
 
-		for i := 0; i < nodesCnt; i++ {
-			result[fmt.Sprintf("%d", i)] = big.NewInt(1)
+		for i := 0; i < int(nodesCnt); i++ {
+			result[fmt.Sprintf("node %d", i)] = big.NewInt(1)
 		}
 
 		return result, nil

--- a/core/ibft.go
+++ b/core/ibft.go
@@ -14,9 +14,9 @@ import (
 
 // Logger represents the logger behaviour
 type Logger interface {
-	Info(msg string, args ...interface{})
-	Debug(msg string, args ...interface{})
-	Error(msg string, args ...interface{})
+	Info(msg string, args ...any)
+	Debug(msg string, args ...any)
+	Error(msg string, args ...any)
 }
 
 // Messages represents the message managing behaviour

--- a/core/ibft.go
+++ b/core/ibft.go
@@ -101,6 +101,7 @@ type IBFT struct {
 	// state modification routines
 	wg sync.WaitGroup
 
+	// validatorManager keeps quorumSize and voting power information
 	validatorManager *ValidatorManager
 }
 
@@ -296,7 +297,7 @@ func (i *IBFT) RunSequence(ctx context.Context, h uint64) {
 	i.state.reset(h)
 
 	// init validator manager
-	votingPowerMap, err := i.backend.GetVotingPower(h)
+	votingPowerMap, err := i.backend.GetVotingPowers(h)
 	if err != nil {
 		i.log.Error("failed to run sequence get voting power", "height", h, "error", err)
 

--- a/core/ibft.go
+++ b/core/ibft.go
@@ -130,7 +130,7 @@ func NewIBFT(
 			name:         newRound,
 		},
 		baseRoundTimeout: round0Timeout,
-		validatorManager: NewValidatorManager(backend, log),
+		validatorManager: newValidatorManager(backend, log),
 	}
 }
 
@@ -296,7 +296,7 @@ func (i *IBFT) RunSequence(ctx context.Context, h uint64) {
 	// Set the starting state data
 	i.state.reset(h)
 
-	if err := i.validatorManager.Init(h); err != nil {
+	if err := i.validatorManager.init(h); err != nil {
 		i.log.Error("failed to run sequence - validator manager init", "height", h, "error", err)
 
 		return
@@ -1150,7 +1150,7 @@ func (i *IBFT) validPC(
 
 	// Make sure there are at least Quorum (PP + P) messages
 	// hasQuorum directly since the messages are of different types
-	if !i.validatorManager.HasQuorum(convertMessageToAddressSet(allMessages)) {
+	if !i.validatorManager.hasQuorum(convertMessageToAddressSet(allMessages)) {
 		return false
 	}
 
@@ -1259,9 +1259,9 @@ func (i *IBFT) hasQuorumByMsgType(msgs []*proto.Message, msgType proto.MessageTy
 	case proto.MessageType_PREPREPARE:
 		return len(msgs) >= 1
 	case proto.MessageType_PREPARE:
-		return i.validatorManager.HasPrepareQuorum(i.state.getProposalMessage(), msgs)
+		return i.validatorManager.hasPrepareQuorum(i.state.getProposalMessage(), msgs)
 	case proto.MessageType_ROUND_CHANGE, proto.MessageType_COMMIT:
-		return i.validatorManager.HasQuorum(convertMessageToAddressSet(msgs))
+		return i.validatorManager.hasQuorum(convertMessageToAddressSet(msgs))
 	default:
 		return false
 	}

--- a/core/ibft.go
+++ b/core/ibft.go
@@ -1267,7 +1267,7 @@ func (i *IBFT) hasQuorumByMsgType(msgs []*proto.Message, msgType proto.MessageTy
 	case proto.MessageType_PREPREPARE:
 		return len(msgs) >= 1
 	case proto.MessageType_PREPARE:
-		return i.validatorManager.HasPrepareQuorum(i.state.proposalMessage, msgs)
+		return i.validatorManager.HasPrepareQuorum(i.state.getProposalMessage(), msgs)
 	case proto.MessageType_ROUND_CHANGE, proto.MessageType_COMMIT:
 		return i.validatorManager.HasQuorum(ConvertMessageToAddressSet(msgs))
 	default:

--- a/core/ibft.go
+++ b/core/ibft.go
@@ -102,7 +102,7 @@ type IBFT struct {
 	wg sync.WaitGroup
 
 	// validatorManager keeps quorumSize and voting power information
-	validatorManager *ValidatorManager
+	validatorManager *validatorManager
 }
 
 // NewIBFT creates a new instance of the IBFT consensus protocol

--- a/core/ibft.go
+++ b/core/ibft.go
@@ -102,7 +102,7 @@ type IBFT struct {
 	wg sync.WaitGroup
 
 	// validatorManager keeps quorumSize and voting power information
-	validatorManager *validatorManager
+	validatorManager *ValidatorManager
 }
 
 // NewIBFT creates a new instance of the IBFT consensus protocol
@@ -130,7 +130,7 @@ func NewIBFT(
 			name:         newRound,
 		},
 		baseRoundTimeout: round0Timeout,
-		validatorManager: newValidatorManager(backend, log),
+		validatorManager: NewValidatorManager(backend, log),
 	}
 }
 
@@ -296,7 +296,7 @@ func (i *IBFT) RunSequence(ctx context.Context, h uint64) {
 	// Set the starting state data
 	i.state.reset(h)
 
-	if err := i.validatorManager.init(h); err != nil {
+	if err := i.validatorManager.Init(h); err != nil {
 		i.log.Error("failed to run sequence - validator manager init", "height", h, "error", err)
 
 		return
@@ -1150,7 +1150,7 @@ func (i *IBFT) validPC(
 
 	// Make sure there are at least Quorum (PP + P) messages
 	// hasQuorum directly since the messages are of different types
-	if !i.validatorManager.hasQuorum(convertMessageToAddressSet(allMessages)) {
+	if !i.validatorManager.HasQuorum(convertMessageToAddressSet(allMessages)) {
 		return false
 	}
 
@@ -1259,9 +1259,9 @@ func (i *IBFT) hasQuorumByMsgType(msgs []*proto.Message, msgType proto.MessageTy
 	case proto.MessageType_PREPREPARE:
 		return len(msgs) >= 1
 	case proto.MessageType_PREPARE:
-		return i.validatorManager.hasPrepareQuorum(i.state.getProposalMessage(), msgs)
+		return i.validatorManager.HasPrepareQuorum(i.state.getProposalMessage(), msgs)
 	case proto.MessageType_ROUND_CHANGE, proto.MessageType_COMMIT:
-		return i.validatorManager.hasQuorum(convertMessageToAddressSet(msgs))
+		return i.validatorManager.HasQuorum(convertMessageToAddressSet(msgs))
 	default:
 		return false
 	}

--- a/core/ibft_test.go
+++ b/core/ibft_test.go
@@ -569,7 +569,7 @@ func TestRunNewRound_Proposer(t *testing.T) {
 			)
 
 			i := NewIBFT(log, backend, transport)
-			require.NoError(t, i.validatorManager.init(0))
+			require.NoError(t, i.validatorManager.Init(0))
 			i.messages = messages
 			i.state.setView(&proto.View{
 				Height: 0,
@@ -838,7 +838,7 @@ func TestRunNewRound_Validator_NonZero(t *testing.T) {
 			)
 
 			i := NewIBFT(log, backend, transport)
-			require.NoError(t, i.validatorManager.init(0))
+			require.NoError(t, i.validatorManager.Init(0))
 			i.messages = messages
 			i.state.setView(&proto.View{
 				Height: 0,
@@ -939,7 +939,7 @@ func TestRunPrepare(t *testing.T) {
 			)
 
 			i := NewIBFT(log, backend, transport)
-			require.NoError(t, i.validatorManager.init(0))
+			require.NoError(t, i.validatorManager.Init(0))
 			i.state.name = prepare
 			i.state.roundStarted = true
 			i.state.proposalMessage = &proto.Message{
@@ -1042,7 +1042,7 @@ func TestRunCommit(t *testing.T) {
 			)
 
 			i := NewIBFT(log, backend, transport)
-			require.NoError(t, i.validatorManager.init(0))
+			require.NoError(t, i.validatorManager.Init(0))
 			i.messages = messages
 			i.state.proposalMessage = &proto.Message{
 				Payload: &proto.Message_PreprepareData{
@@ -1460,7 +1460,7 @@ func TestIBFT_FutureProposal(t *testing.T) {
 			)
 
 			i := NewIBFT(log, backend, transport)
-			require.NoError(t, i.validatorManager.init(0))
+			require.NoError(t, i.validatorManager.Init(0))
 			i.messages = mMessages
 
 			wg.Add(1)
@@ -1987,7 +1987,7 @@ func TestIBFT_ValidPC(t *testing.T) {
 		)
 
 		i := NewIBFT(log, backend, transport)
-		require.NoError(t, i.validatorManager.init(0))
+		require.NoError(t, i.validatorManager.Init(0))
 		proposal := generateMessagesWithSender(1, proto.MessageType_PREPREPARE, sender)[0]
 
 		certificate := &proto.PreparedCertificate{
@@ -2454,7 +2454,7 @@ func TestIBFT_WatchForFutureRCC(t *testing.T) {
 	)
 
 	i := NewIBFT(log, backend, transport)
-	require.NoError(t, i.validatorManager.init(uint64(0)))
+	require.NoError(t, i.validatorManager.Init(uint64(0)))
 
 	i.messages = messages
 
@@ -2735,7 +2735,7 @@ func TestIBFT_AddMessage(t *testing.T) {
 		}
 
 		i := NewIBFT(log, backend, transport)
-		require.NoError(t, i.validatorManager.init(0))
+		require.NoError(t, i.validatorManager.Init(0))
 		i.messages = messages
 		i.state.view = &proto.View{Height: validHeight, Round: validRound}
 

--- a/core/ibft_test.go
+++ b/core/ibft_test.go
@@ -569,8 +569,7 @@ func TestRunNewRound_Proposer(t *testing.T) {
 			)
 
 			i := NewIBFT(log, backend, transport)
-			votingPowers, _ := i.backend.GetVotingPowers(0)
-			require.NoError(t, i.validatorManager.Init(votingPowers))
+			require.NoError(t, i.validatorManager.Init(0))
 			i.messages = messages
 			i.state.setView(&proto.View{
 				Height: 0,
@@ -839,8 +838,7 @@ func TestRunNewRound_Validator_NonZero(t *testing.T) {
 			)
 
 			i := NewIBFT(log, backend, transport)
-			votingPowers, _ := i.backend.GetVotingPowers(0)
-			require.NoError(t, i.validatorManager.Init(votingPowers))
+			require.NoError(t, i.validatorManager.Init(0))
 			i.messages = messages
 			i.state.setView(&proto.View{
 				Height: 0,
@@ -941,8 +939,7 @@ func TestRunPrepare(t *testing.T) {
 			)
 
 			i := NewIBFT(log, backend, transport)
-			votingPowers, _ := i.backend.GetVotingPowers(0)
-			require.NoError(t, i.validatorManager.Init(votingPowers))
+			require.NoError(t, i.validatorManager.Init(0))
 			i.state.name = prepare
 			i.state.roundStarted = true
 			i.state.proposalMessage = &proto.Message{
@@ -1045,8 +1042,7 @@ func TestRunCommit(t *testing.T) {
 			)
 
 			i := NewIBFT(log, backend, transport)
-			votingPowers, _ := i.backend.GetVotingPowers(0)
-			require.NoError(t, i.validatorManager.Init(votingPowers))
+			require.NoError(t, i.validatorManager.Init(0))
 			i.messages = messages
 			i.state.proposalMessage = &proto.Message{
 				Payload: &proto.Message_PreprepareData{
@@ -1464,8 +1460,7 @@ func TestIBFT_FutureProposal(t *testing.T) {
 			)
 
 			i := NewIBFT(log, backend, transport)
-			votingPowers, _ := i.backend.GetVotingPowers(0)
-			require.NoError(t, i.validatorManager.Init(votingPowers))
+			require.NoError(t, i.validatorManager.Init(0))
 			i.messages = mMessages
 
 			wg.Add(1)
@@ -1992,9 +1987,7 @@ func TestIBFT_ValidPC(t *testing.T) {
 		)
 
 		i := NewIBFT(log, backend, transport)
-		votingPowers, _ := i.backend.GetVotingPowers(0)
-		require.NoError(t, i.validatorManager.Init(votingPowers))
-
+		require.NoError(t, i.validatorManager.Init(0))
 		proposal := generateMessagesWithSender(1, proto.MessageType_PREPREPARE, sender)[0]
 
 		certificate := &proto.PreparedCertificate{
@@ -2461,8 +2454,7 @@ func TestIBFT_WatchForFutureRCC(t *testing.T) {
 	)
 
 	i := NewIBFT(log, backend, transport)
-	votingPowers, _ := i.backend.GetVotingPowers(0)
-	require.NoError(t, i.validatorManager.Init(votingPowers))
+	require.NoError(t, i.validatorManager.Init(uint64(0)))
 
 	i.messages = messages
 
@@ -2743,8 +2735,7 @@ func TestIBFT_AddMessage(t *testing.T) {
 		}
 
 		i := NewIBFT(log, backend, transport)
-		votingPowers, _ := i.backend.GetVotingPowers(0)
-		require.NoError(t, i.validatorManager.Init(votingPowers))
+		require.NoError(t, i.validatorManager.Init(0))
 		i.messages = messages
 		i.state.view = &proto.View{Height: validHeight, Round: validRound}
 

--- a/core/ibft_test.go
+++ b/core/ibft_test.go
@@ -213,7 +213,7 @@ func generateFilledRCMessages(
 }
 
 func defaultHasQuorumFn(quorum uint64) hasQuorumDelegate {
-	return func(_ uint64, messages []*proto.Message, msgType proto.MessageType) bool {
+	return func(messages []*proto.Message, msgType proto.MessageType) bool {
 		return len(messages) >= int(quorum)
 	}
 }
@@ -626,7 +626,7 @@ func TestRunNewRound_Validator_Zero(t *testing.T) {
 			idFn: func() []byte {
 				return []byte("non proposer")
 			},
-			hasQuorumFn: func(_ uint64, messages []*proto.Message, _ proto.MessageType) bool {
+			hasQuorumFn: func(messages []*proto.Message, _ proto.MessageType) bool {
 				return len(messages) >= 1
 			},
 			buildPrepareMessageFn: func(proposal []byte, view *proto.View) *proto.Message {
@@ -799,7 +799,7 @@ func TestRunNewRound_Validator_NonZero(t *testing.T) {
 					idFn: func() []byte {
 						return []byte("non proposer")
 					},
-					hasQuorumFn: func(_ uint64, messages []*proto.Message, _ proto.MessageType) bool {
+					hasQuorumFn: func(messages []*proto.Message, _ proto.MessageType) bool {
 						return len(messages) >= 1
 					},
 					buildPrepareMessageFn: func(proposal []byte, view *proto.View) *proto.Message {
@@ -906,7 +906,7 @@ func TestRunPrepare(t *testing.T) {
 							},
 						}
 					},
-					hasQuorumFn: func(_ uint64, messages []*proto.Message, _ proto.MessageType) bool {
+					hasQuorumFn: func(messages []*proto.Message, _ proto.MessageType) bool {
 						return len(messages) >= 1
 					},
 					isValidProposalHashFn: func(_ *proto.Proposal, hash []byte) bool {
@@ -1011,7 +1011,7 @@ func TestRunCommit(t *testing.T) {
 						insertedProposal = proposal.RawProposal
 						insertedCommittedSeals = committedSeals
 					},
-					hasQuorumFn: func(_ uint64, messages []*proto.Message, _ proto.MessageType) bool {
+					hasQuorumFn: func(messages []*proto.Message, _ proto.MessageType) bool {
 						return len(messages) >= 1
 					},
 					isValidProposalHashFn: func(_ *proto.Proposal, hash []byte) bool {
@@ -2721,10 +2721,10 @@ func TestIBFT_AddMessage(t *testing.T) {
 			return bytes.Equal(m.From, validSender)
 		}
 
-		backend.hasQuorumFn = func(height uint64, _ []*proto.Message, msgType proto.MessageType) bool {
+		backend.hasQuorumFn = func(msgs []*proto.Message, msgType proto.MessageType) bool {
 			hasQuorumCalled = true
 
-			assert.Equal(t, validHeight, height)
+			assert.Equal(t, validHeight, msgs[0].View.Height)
 			assert.Equal(t, validMsgType, msgType)
 
 			return hasQuorum

--- a/core/ibft_test.go
+++ b/core/ibft_test.go
@@ -569,7 +569,7 @@ func TestRunNewRound_Proposer(t *testing.T) {
 			)
 
 			i := NewIBFT(log, backend, transport)
-			require.NoError(t, i.validatorManager.Init(0))
+			require.NoError(t, i.validatorManager.init(0))
 			i.messages = messages
 			i.state.setView(&proto.View{
 				Height: 0,
@@ -838,7 +838,7 @@ func TestRunNewRound_Validator_NonZero(t *testing.T) {
 			)
 
 			i := NewIBFT(log, backend, transport)
-			require.NoError(t, i.validatorManager.Init(0))
+			require.NoError(t, i.validatorManager.init(0))
 			i.messages = messages
 			i.state.setView(&proto.View{
 				Height: 0,
@@ -939,7 +939,7 @@ func TestRunPrepare(t *testing.T) {
 			)
 
 			i := NewIBFT(log, backend, transport)
-			require.NoError(t, i.validatorManager.Init(0))
+			require.NoError(t, i.validatorManager.init(0))
 			i.state.name = prepare
 			i.state.roundStarted = true
 			i.state.proposalMessage = &proto.Message{
@@ -1042,7 +1042,7 @@ func TestRunCommit(t *testing.T) {
 			)
 
 			i := NewIBFT(log, backend, transport)
-			require.NoError(t, i.validatorManager.Init(0))
+			require.NoError(t, i.validatorManager.init(0))
 			i.messages = messages
 			i.state.proposalMessage = &proto.Message{
 				Payload: &proto.Message_PreprepareData{
@@ -1460,7 +1460,7 @@ func TestIBFT_FutureProposal(t *testing.T) {
 			)
 
 			i := NewIBFT(log, backend, transport)
-			require.NoError(t, i.validatorManager.Init(0))
+			require.NoError(t, i.validatorManager.init(0))
 			i.messages = mMessages
 
 			wg.Add(1)
@@ -1987,7 +1987,7 @@ func TestIBFT_ValidPC(t *testing.T) {
 		)
 
 		i := NewIBFT(log, backend, transport)
-		require.NoError(t, i.validatorManager.Init(0))
+		require.NoError(t, i.validatorManager.init(0))
 		proposal := generateMessagesWithSender(1, proto.MessageType_PREPREPARE, sender)[0]
 
 		certificate := &proto.PreparedCertificate{
@@ -2454,7 +2454,7 @@ func TestIBFT_WatchForFutureRCC(t *testing.T) {
 	)
 
 	i := NewIBFT(log, backend, transport)
-	require.NoError(t, i.validatorManager.Init(uint64(0)))
+	require.NoError(t, i.validatorManager.init(uint64(0)))
 
 	i.messages = messages
 
@@ -2735,7 +2735,7 @@ func TestIBFT_AddMessage(t *testing.T) {
 		}
 
 		i := NewIBFT(log, backend, transport)
-		require.NoError(t, i.validatorManager.Init(0))
+		require.NoError(t, i.validatorManager.init(0))
 		i.messages = messages
 		i.state.view = &proto.View{Height: validHeight, Round: validRound}
 

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -62,7 +63,8 @@ type buildRoundChangeMessageDelegate func(
 
 type insertProposalDelegate func(*proto.Proposal, []*messages.CommittedSeal)
 type idDelegate func() []byte
-type hasQuorumDelegate func(uint64, []*proto.Message, proto.MessageType) bool
+type hasQuorumDelegate func([]*proto.Message, proto.MessageType) bool
+type getVotingPowerDelegate func(uint64) (map[string]*big.Int, error)
 
 // mockBackend is the mock backend structure that is configurable
 type mockBackend struct {
@@ -80,6 +82,7 @@ type mockBackend struct {
 	insertProposalFn          insertProposalDelegate
 	idFn                      idDelegate
 	hasQuorumFn               hasQuorumDelegate
+	getVotingPowerFn          getVotingPowerDelegate
 }
 
 func (m mockBackend) ID() []byte {
@@ -193,10 +196,18 @@ func (m mockBackend) BuildRoundChangeMessage(
 
 func (m mockBackend) HasQuorum(height uint64, messages []*proto.Message, msgType proto.MessageType) bool {
 	if m.hasQuorumFn != nil {
-		return m.hasQuorumFn(height, messages, msgType)
+		return m.hasQuorumFn(messages, msgType)
 	}
 
 	return true
+}
+
+func (m mockBackend) GetVotingPower(height uint64) (map[string]*big.Int, error) {
+	if m.getVotingPowerFn != nil {
+		return m.getVotingPowerFn(height)
+	}
+
+	return map[string]*big.Int{}, nil
 }
 
 // Define delegation methods

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -63,8 +63,9 @@ type buildRoundChangeMessageDelegate func(
 
 type insertProposalDelegate func(*proto.Proposal, []*messages.CommittedSeal)
 type idDelegate func() []byte
-type hasQuorumDelegate func([]*proto.Message, proto.MessageType) bool
 type getVotingPowerDelegate func(uint64) (map[string]*big.Int, error)
+
+var _ Backend = &mockBackend{}
 
 // mockBackend is the mock backend structure that is configurable
 type mockBackend struct {
@@ -81,7 +82,6 @@ type mockBackend struct {
 	buildRoundChangeMessageFn buildRoundChangeMessageDelegate
 	insertProposalFn          insertProposalDelegate
 	idFn                      idDelegate
-	hasQuorumFn               hasQuorumDelegate
 	getVotingPowerFn          getVotingPowerDelegate
 }
 
@@ -192,14 +192,6 @@ func (m mockBackend) BuildRoundChangeMessage(
 		Type:    proto.MessageType_ROUND_CHANGE,
 		Payload: nil,
 	}
-}
-
-func (m mockBackend) HasQuorum(height uint64, messages []*proto.Message, msgType proto.MessageType) bool {
-	if m.hasQuorumFn != nil {
-		return m.hasQuorumFn(messages, msgType)
-	}
-
-	return true
 }
 
 func (m mockBackend) GetVotingPower(height uint64) (map[string]*big.Int, error) {

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -194,7 +194,7 @@ func (m mockBackend) BuildRoundChangeMessage(
 	}
 }
 
-func (m mockBackend) GetVotingPower(height uint64) (map[string]*big.Int, error) {
+func (m mockBackend) GetVotingPowers(height uint64) (map[string]*big.Int, error) {
 	if m.getVotingPowerFn != nil {
 		return m.getVotingPowerFn(height)
 	}

--- a/core/rapid_test.go
+++ b/core/rapid_test.go
@@ -205,6 +205,7 @@ func generatePropertyTestEvent(t *rapid.T) *propertyTestSetup {
 // that assures the cluster can handle rounds properly in any cases.
 func TestProperty(t *testing.T) {
 	t.Parallel()
+	t.Skip()
 
 	rapid.Check(t, func(t *rapid.T) {
 		var multicastFn func(message *proto.Message)
@@ -236,7 +237,7 @@ func TestProperty(t *testing.T) {
 		// for the Backend, for all nodes
 		commonBackendCallback := func(backend *mockBackend, nodeIndex int) {
 			// Make sure the quorum function is Quorum optimal
-			backend.hasQuorumFn = commonHasQuorumFn(setup.nodes)
+			backend.getVotingPowerFn = testCommonGetVotingPowertFn(nodes)
 
 			// Make sure the node ID is properly relayed
 			backend.idFn = func() []byte {

--- a/core/rapid_test.go
+++ b/core/rapid_test.go
@@ -205,6 +205,7 @@ func generatePropertyTestEvent(t *rapid.T) *propertyTestSetup {
 // that assures the cluster can handle rounds properly in any cases.
 func TestProperty(t *testing.T) {
 	t.Parallel()
+	t.Skip()
 
 	rapid.Check(t, func(t *rapid.T) {
 		var multicastFn func(message *proto.Message)

--- a/core/rapid_test.go
+++ b/core/rapid_test.go
@@ -205,7 +205,6 @@ func generatePropertyTestEvent(t *rapid.T) *propertyTestSetup {
 // that assures the cluster can handle rounds properly in any cases.
 func TestProperty(t *testing.T) {
 	t.Parallel()
-	t.Skip()
 
 	rapid.Check(t, func(t *rapid.T) {
 		var multicastFn func(message *proto.Message)

--- a/core/state.go
+++ b/core/state.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"math/big"
 	"sync"
 
 	"github.com/0xPolygon/go-ibft/messages"
@@ -54,6 +55,14 @@ type state struct {
 	roundStarted bool
 
 	name stateType
+
+	// quorumSize represents quorum for the height specified in the current View
+	quorumSize *big.Int
+
+	// validatorsVotingPower is a map of the validator addresses on their voting power for
+	// the height specified in the current View
+	//TODO add address instead of string
+	validatorsVotingPower map[string]*big.Int
 }
 
 func (s *state) getView() *proto.View {
@@ -66,7 +75,7 @@ func (s *state) getView() *proto.View {
 	}
 }
 
-func (s *state) clear(height uint64) {
+func (s *state) reset(i *IBFT, height uint64) error {
 	s.Lock()
 	defer s.Unlock()
 
@@ -81,6 +90,8 @@ func (s *state) clear(height uint64) {
 		Height: height,
 		Round:  0,
 	}
+
+	return s.setQuorumData(i)
 }
 
 func (s *state) getLatestPC() *proto.PreparedCertificate {
@@ -218,4 +229,42 @@ func (s *state) finalizePrepare(
 
 	// Move to the commit state
 	s.name = commit
+}
+
+func (s *state) setQuorumData(i *IBFT) error {
+	var err error
+	if s.validatorsVotingPower, err = i.backend.GetVotingPower(s.view.Height); err != nil {
+		return err
+	}
+
+	totalVotingPower := calculateTotalVotingPower(s.validatorsVotingPower)
+	s.quorumSize = calculateQuorum(totalVotingPower)
+
+	return nil
+}
+
+func calculateQuorum(totalVotingPower *big.Int) *big.Int {
+	quorum := new(big.Int)
+	quorum.Mul(totalVotingPower, big.NewInt(2))
+
+	return BigIntDivCeil(quorum, big.NewInt(3))
+}
+
+func calculateTotalVotingPower(validatorsVotingPower map[string]*big.Int) *big.Int {
+	totalVotingPower := big.NewInt(0)
+	for _, validatorVotingPower := range validatorsVotingPower {
+		totalVotingPower = totalVotingPower.Add(totalVotingPower, validatorVotingPower)
+	}
+
+	return totalVotingPower
+}
+
+// BigIntDivCeil performs integer division and rounds given result to next bigger integer number
+// It is calculated using this formula result = (a + b - 1) / b
+func BigIntDivCeil(a, b *big.Int) *big.Int {
+	result := new(big.Int)
+
+	return result.Add(a, b).
+		Sub(result, big.NewInt(1)).
+		Div(result, b)
 }

--- a/core/validator_manager.go
+++ b/core/validator_manager.go
@@ -19,8 +19,8 @@ type ValidatorBackend interface {
 	GetVotingPowers(height uint64) (map[string]*big.Int, error)
 }
 
-// ValidatorManager keeps voting power and other information about validators
-type ValidatorManager struct {
+// validatorManager keeps voting power and other information about validators
+type validatorManager struct {
 	vpLock *sync.RWMutex
 
 	// quorumSize represents quorum for the height specified in the current View
@@ -36,8 +36,8 @@ type ValidatorManager struct {
 }
 
 // NewValidatorManager creates new ValidatorManager
-func NewValidatorManager(backend ValidatorBackend, log Logger) *ValidatorManager {
-	return &ValidatorManager{
+func NewValidatorManager(backend ValidatorBackend, log Logger) *validatorManager {
+	return &validatorManager{
 		quorumSize:            big.NewInt(0),
 		backend:               backend,
 		validatorsVotingPower: nil,
@@ -47,7 +47,7 @@ func NewValidatorManager(backend ValidatorBackend, log Logger) *ValidatorManager
 }
 
 // Init sets voting power and quorum size
-func (vm *ValidatorManager) Init(height uint64) error {
+func (vm *validatorManager) Init(height uint64) error {
 	vm.vpLock.Lock()
 	defer vm.vpLock.Unlock()
 
@@ -68,7 +68,7 @@ func (vm *ValidatorManager) Init(height uint64) error {
 }
 
 // HasQuorum provides information on whether messages have reached the quorum
-func (vm *ValidatorManager) HasQuorum(sendersAddrs map[string]struct{}) bool {
+func (vm *validatorManager) HasQuorum(sendersAddrs map[string]struct{}) bool {
 	vm.vpLock.RLock()
 	defer vm.vpLock.RUnlock()
 
@@ -89,7 +89,7 @@ func (vm *ValidatorManager) HasQuorum(sendersAddrs map[string]struct{}) bool {
 }
 
 // HasPrepareQuorum provides information on whether prepared messages have reached the quorum
-func (vm *ValidatorManager) HasPrepareQuorum(proposalMessage *proto.Message, msgs []*proto.Message) bool {
+func (vm *validatorManager) HasPrepareQuorum(proposalMessage *proto.Message, msgs []*proto.Message) bool {
 	if proposalMessage == nil {
 		vm.log.Error("HasPrepareQuorum - proposalMessage is not set")
 
@@ -123,7 +123,7 @@ func calculateQuorum(totalVotingPower *big.Int) *big.Int {
 func calculateTotalVotingPower(validatorsVotingPower map[string]*big.Int) *big.Int {
 	totalVotingPower := big.NewInt(0)
 	for _, validatorVotingPower := range validatorsVotingPower {
-		totalVotingPower = totalVotingPower.Add(totalVotingPower, validatorVotingPower)
+		totalVotingPower.Add(totalVotingPower, validatorVotingPower)
 	}
 
 	return totalVotingPower

--- a/core/validator_manager.go
+++ b/core/validator_manager.go
@@ -66,8 +66,6 @@ func (vm *ValidatorManager) HasQuorum(addressMap map[string]struct{}) bool {
 
 // HasPrepareQuorum provides information on whether prepared messages have reached the quorum
 func (vm *ValidatorManager) HasPrepareQuorum(proposalMessage *proto.Message, msgs []*proto.Message) bool {
-	// TODO get proposer from the backend for the specific round and height
-	// or expect that the proposal is accepted and that the right one??
 	if proposalMessage == nil {
 		vm.log.Info("HasPrepareQuorum - proposalMessage is not set")
 

--- a/core/validator_manager.go
+++ b/core/validator_manager.go
@@ -1,0 +1,129 @@
+package core
+
+import (
+	"bytes"
+	"errors"
+	"math/big"
+
+	"github.com/0xPolygon/go-ibft/messages/proto"
+)
+
+var (
+	errVotingPowerNotCorrect = errors.New("total voting power is zero or less")
+)
+
+// ValidatorManager keeps voting power and other informations about validators
+type ValidatorManager struct {
+	// quorumSize represents quorum for the height specified in the current View
+	quorumSize *big.Int
+
+	// validatorsVotingPower is a map of the validator addresses on their voting power for
+	// the height specified in the current View
+	validatorsVotingPower map[string]*big.Int
+
+	log Logger
+}
+
+// NewValidatorManager creates new ValidatorManager
+func NewValidatorManager(log Logger) *ValidatorManager {
+	return &ValidatorManager{
+		quorumSize:            big.NewInt(0),
+		validatorsVotingPower: nil,
+		log:                   log,
+	}
+}
+
+// Init sets voting power and quorum size
+func (vm *ValidatorManager) Init(validatorsVotingPower map[string]*big.Int) error {
+	totalVotingPower := calculateTotalVotingPower(validatorsVotingPower)
+	if totalVotingPower.Cmp(big.NewInt(0)) <= 0 {
+		return errVotingPowerNotCorrect
+	}
+
+	vm.validatorsVotingPower = validatorsVotingPower
+	vm.quorumSize = calculateQuorum(totalVotingPower)
+
+	return nil
+}
+
+// HasQuorum provides information on whether messages have reached the quorum
+func (vm *ValidatorManager) HasQuorum(addressMap map[string]struct{}) bool {
+	// if not initialized correctly return false
+	if vm.validatorsVotingPower == nil {
+		return false
+	}
+
+	messageVotePower := big.NewInt(0)
+
+	for from := range addressMap {
+		if vote, ok := vm.validatorsVotingPower[from]; ok {
+			messageVotePower.Add(messageVotePower, vote)
+		}
+	}
+
+	return messageVotePower.Cmp(vm.quorumSize) >= 0
+}
+
+// HasPrepareQuorum provides information on whether prepared messages have reached the quorum
+func (vm *ValidatorManager) HasPrepareQuorum(proposalMessage *proto.Message, msgs []*proto.Message) bool {
+	// TODO get proposer from the backend for the specific round and height
+	// or expect that the proposal is accepted and that the right one??
+	if proposalMessage == nil {
+		vm.log.Info("HasPrepareQuorum - proposalMessage is not set")
+
+		return false
+	}
+
+	proposerAddress := proposalMessage.From
+	sendersAddressesMap := map[string]struct{}{
+		string(proposerAddress): {},
+	}
+
+	for _, message := range msgs {
+		if bytes.Equal(message.From, proposerAddress) {
+			vm.log.Info("HasPrepareQuorum - proposer is among signers but it is not expected to be")
+
+			return false
+		}
+
+		sendersAddressesMap[string(message.From)] = struct{}{}
+	}
+
+	return vm.HasQuorum(sendersAddressesMap)
+}
+
+func calculateQuorum(totalVotingPower *big.Int) *big.Int {
+	quorum := new(big.Int).Mul(totalVotingPower, big.NewInt(2))
+
+	return bigIntDivCeil(quorum, big.NewInt(3))
+}
+
+func calculateTotalVotingPower(validatorsVotingPower map[string]*big.Int) *big.Int {
+	totalVotingPower := big.NewInt(0)
+	for _, validatorVotingPower := range validatorsVotingPower {
+		totalVotingPower = totalVotingPower.Add(totalVotingPower, validatorVotingPower)
+	}
+
+	return totalVotingPower
+}
+
+// bigIntDivCeil performs integer division and rounds given result to next bigger integer number
+// It is calculated using this formula result = (a + b - 1) / b
+func bigIntDivCeil(a, b *big.Int) *big.Int {
+	result := new(big.Int)
+
+	return result.Add(a, b).
+		Sub(result, big.NewInt(1)).
+		Div(result, b)
+}
+
+// ConvertMessageToAddressSet converts messages slice to addresses map
+func ConvertMessageToAddressSet(messages []*proto.Message) map[string]struct{} {
+	result := make(map[string]struct{}, len(messages))
+
+	for _, x := range messages {
+		result[string(x.From)] = struct{}{}
+	}
+
+	return result
+}

--- a/core/validator_manager.go
+++ b/core/validator_manager.go
@@ -19,8 +19,8 @@ type ValidatorBackend interface {
 	GetVotingPowers(height uint64) (map[string]*big.Int, error)
 }
 
-// validatorManager keeps voting power and other information about validators
-type validatorManager struct {
+// ValidatorManager keeps voting power and other information about validators
+type ValidatorManager struct {
 	vpLock *sync.RWMutex
 
 	// quorumSize represents quorum for the height specified in the current View
@@ -35,9 +35,9 @@ type validatorManager struct {
 	log Logger
 }
 
-// newValidatorManager creates new ValidatorManager
-func newValidatorManager(backend ValidatorBackend, log Logger) *validatorManager {
-	return &validatorManager{
+// NewValidatorManager creates new ValidatorManager
+func NewValidatorManager(backend ValidatorBackend, log Logger) *ValidatorManager {
+	return &ValidatorManager{
 		quorumSize:            big.NewInt(0),
 		backend:               backend,
 		validatorsVotingPower: nil,
@@ -46,8 +46,8 @@ func newValidatorManager(backend ValidatorBackend, log Logger) *validatorManager
 	}
 }
 
-// init sets voting power and quorum size
-func (vm *validatorManager) init(height uint64) error {
+// Init sets voting power and quorum size
+func (vm *ValidatorManager) Init(height uint64) error {
 	vm.vpLock.Lock()
 	defer vm.vpLock.Unlock()
 
@@ -67,8 +67,8 @@ func (vm *validatorManager) init(height uint64) error {
 	return nil
 }
 
-// hasQuorum provides information on whether messages have reached the quorum
-func (vm *validatorManager) hasQuorum(sendersAddrs map[string]struct{}) bool {
+// HasQuorum provides information on whether messages have reached the quorum
+func (vm *ValidatorManager) HasQuorum(sendersAddrs map[string]struct{}) bool {
 	vm.vpLock.RLock()
 	defer vm.vpLock.RUnlock()
 
@@ -88,8 +88,8 @@ func (vm *validatorManager) hasQuorum(sendersAddrs map[string]struct{}) bool {
 	return messageVotePower.Cmp(vm.quorumSize) >= 0
 }
 
-// hasPrepareQuorum provides information on whether prepared messages have reached the quorum
-func (vm *validatorManager) hasPrepareQuorum(proposalMessage *proto.Message, msgs []*proto.Message) bool {
+// HasPrepareQuorum provides information on whether prepared messages have reached the quorum
+func (vm *ValidatorManager) HasPrepareQuorum(proposalMessage *proto.Message, msgs []*proto.Message) bool {
 	if proposalMessage == nil {
 		vm.log.Error("HasPrepareQuorum - proposalMessage is not set")
 
@@ -111,7 +111,7 @@ func (vm *validatorManager) hasPrepareQuorum(proposalMessage *proto.Message, msg
 		sendersAddressesMap[string(message.From)] = struct{}{}
 	}
 
-	return vm.hasQuorum(sendersAddressesMap)
+	return vm.HasQuorum(sendersAddressesMap)
 }
 
 func calculateQuorum(totalVotingPower *big.Int) *big.Int {

--- a/core/validator_manager.go
+++ b/core/validator_manager.go
@@ -35,8 +35,8 @@ type validatorManager struct {
 	log Logger
 }
 
-// NewValidatorManager creates new ValidatorManager
-func NewValidatorManager(backend ValidatorBackend, log Logger) *validatorManager {
+// newValidatorManager creates new ValidatorManager
+func newValidatorManager(backend ValidatorBackend, log Logger) *validatorManager {
 	return &validatorManager{
 		quorumSize:            big.NewInt(0),
 		backend:               backend,
@@ -46,8 +46,8 @@ func NewValidatorManager(backend ValidatorBackend, log Logger) *validatorManager
 	}
 }
 
-// Init sets voting power and quorum size
-func (vm *validatorManager) Init(height uint64) error {
+// init sets voting power and quorum size
+func (vm *validatorManager) init(height uint64) error {
 	vm.vpLock.Lock()
 	defer vm.vpLock.Unlock()
 
@@ -67,8 +67,8 @@ func (vm *validatorManager) Init(height uint64) error {
 	return nil
 }
 
-// HasQuorum provides information on whether messages have reached the quorum
-func (vm *validatorManager) HasQuorum(sendersAddrs map[string]struct{}) bool {
+// hasQuorum provides information on whether messages have reached the quorum
+func (vm *validatorManager) hasQuorum(sendersAddrs map[string]struct{}) bool {
 	vm.vpLock.RLock()
 	defer vm.vpLock.RUnlock()
 
@@ -88,8 +88,8 @@ func (vm *validatorManager) HasQuorum(sendersAddrs map[string]struct{}) bool {
 	return messageVotePower.Cmp(vm.quorumSize) >= 0
 }
 
-// HasPrepareQuorum provides information on whether prepared messages have reached the quorum
-func (vm *validatorManager) HasPrepareQuorum(proposalMessage *proto.Message, msgs []*proto.Message) bool {
+// hasPrepareQuorum provides information on whether prepared messages have reached the quorum
+func (vm *validatorManager) hasPrepareQuorum(proposalMessage *proto.Message, msgs []*proto.Message) bool {
 	if proposalMessage == nil {
 		vm.log.Error("HasPrepareQuorum - proposalMessage is not set")
 
@@ -111,7 +111,7 @@ func (vm *validatorManager) HasPrepareQuorum(proposalMessage *proto.Message, msg
 		sendersAddressesMap[string(message.From)] = struct{}{}
 	}
 
-	return vm.HasQuorum(sendersAddressesMap)
+	return vm.hasQuorum(sendersAddressesMap)
 }
 
 func calculateQuorum(totalVotingPower *big.Int) *big.Int {

--- a/messages/event_manager.go
+++ b/messages/event_manager.go
@@ -55,9 +55,6 @@ type SubscriptionDetails struct {
 	// HasMinRound is the flag indicating if the
 	// round number is a lower bound
 	HasMinRound bool
-
-	// HasQuorumFn is the function used to check for quorum existence
-	HasQuorumFn func(messages []*proto.Message, msgType proto.MessageType) bool
 }
 
 // subscribe registers a new listener for message events

--- a/messages/event_manager.go
+++ b/messages/event_manager.go
@@ -57,7 +57,7 @@ type SubscriptionDetails struct {
 	HasMinRound bool
 
 	// HasQuorumFn is the function used to check for quorum existence
-	HasQuorumFn func(height uint64, messages []*proto.Message, msgType proto.MessageType) bool
+	HasQuorumFn func(messages []*proto.Message, msgType proto.MessageType) bool
 }
 
 // subscribe registers a new listener for message events

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -29,7 +29,7 @@ func (ms *Messages) Subscribe(details SubscriptionDetails) *Subscription {
 	// Check if any condition is already met
 	msgs := ms.GetValidMessages(details.View, details.MessageType, func(_ *proto.Message) bool { return true })
 
-	if details.HasQuorumFn(details.View.Height, msgs, details.MessageType) {
+	if details.HasQuorumFn(msgs, details.MessageType) {
 		ms.eventManager.signalEvent(details.MessageType, details.View)
 	}
 

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -23,17 +23,7 @@ type Messages struct {
 
 // Subscribe creates a new message type subscription
 func (ms *Messages) Subscribe(details SubscriptionDetails) *Subscription {
-	// Create the subscription
-	subscription := ms.eventManager.subscribe(details)
-
-	// Check if any condition is already met
-	msgs := ms.GetValidMessages(details.View, details.MessageType, func(_ *proto.Message) bool { return true })
-
-	if details.HasQuorumFn(msgs, details.MessageType) {
-		ms.eventManager.signalEvent(details.MessageType, details.View)
-	}
-
-	return subscription
+	return ms.eventManager.subscribe(details)
 }
 
 // Unsubscribe cancels a message type subscription

--- a/messages/messages_test.go
+++ b/messages/messages_test.go
@@ -391,7 +391,7 @@ func TestMessages_EventManager(t *testing.T) {
 	subscription := messages.Subscribe(SubscriptionDetails{
 		MessageType: messageType,
 		View:        baseView,
-		HasQuorumFn: func(_ uint64, messages []*proto.Message, _ proto.MessageType) bool {
+		HasQuorumFn: func(messages []*proto.Message, _ proto.MessageType) bool {
 			return len(messages) >= numMessages
 		},
 	})

--- a/messages/messages_test.go
+++ b/messages/messages_test.go
@@ -391,9 +391,6 @@ func TestMessages_EventManager(t *testing.T) {
 	subscription := messages.Subscribe(SubscriptionDetails{
 		MessageType: messageType,
 		View:        baseView,
-		HasQuorumFn: func(messages []*proto.Message, _ proto.MessageType) bool {
-			return len(messages) >= numMessages
-		},
 	})
 
 	defer messages.Unsubscribe(subscription.ID)


### PR DESCRIPTION
# Description

`HasQuorum` used to be a function implemented by `Backend`. By introducing this PR `Backend` only provides `GetVotingPowers` function which returns validators' addresses and their voting power. Calculation of quorum is a task of go-ibft.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Interface beetwen go-ibft and backend has been changed. 

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have added sufficient documentation in code
