### PR TITLE
SignalEvent on subscription panic

### DIFF
--- a/core/ibft.go
+++ b/core/ibft.go
@@ -25,7 +25,7 @@ type Messages interface {
 	AddMessage(message *proto.Message)
 	PruneByHeight(height uint64)
 
-	SignalEvent(message *proto.Message)
+	SignalEvent(messageType proto.MessageType, view *proto.View)
 
 	// Messages fetchers //
 	GetValidMessages(
@@ -1085,7 +1085,7 @@ func (i *IBFT) AddMessage(message *proto.Message) {
 				message.Type,
 				func(_ *proto.Message) bool { return true })
 			if i.hasQuorumByMsgType(msgs, message.Type) {
-				i.messages.SignalEvent(message)
+				i.messages.SignalEvent(message.Type, message.View)
 			}
 		}
 	}
@@ -1275,11 +1275,7 @@ func (i *IBFT) subscribe(details messages.SubscriptionDetails) *messages.Subscri
 		func(_ *proto.Message) bool { return true })
 	// Check if any condition is already met
 	if i.hasQuorumByMsgType(msgs, details.MessageType) {
-		if len(msgs) > 0 {
-			i.messages.SignalEvent(msgs[0])
-		} else {
-			i.messages.SignalEvent(i.state.getProposalMessage())
-		}
+		i.messages.SignalEvent(details.MessageType, details.View)
 	}
 
 	return subscription

--- a/core/ibft.go
+++ b/core/ibft.go
@@ -1275,7 +1275,11 @@ func (i *IBFT) subscribe(details messages.SubscriptionDetails) *messages.Subscri
 		func(_ *proto.Message) bool { return true })
 	// Check if any condition is already met
 	if i.hasQuorumByMsgType(msgs, details.MessageType) {
-		i.messages.SignalEvent(msgs[0])
+		if len(msgs) > 0 {
+			i.messages.SignalEvent(msgs[0])
+		} else {
+			i.messages.SignalEvent(i.state.getProposalMessage())
+		}
 	}
 
 	return subscription

--- a/core/ibft_test.go
+++ b/core/ibft_test.go
@@ -2730,7 +2730,7 @@ func TestIBFT_AddMessage(t *testing.T) {
 			assert.Equal(t, msg, m)
 		}
 
-		messages.signalEventFn = func(*proto.Message) {
+		messages.signalEventFn = func(messageType proto.MessageType, messageView *proto.View) {
 			signalEventCalled = true
 		}
 

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -247,7 +247,7 @@ func (l mockLogger) Error(msg string, args ...interface{}) {
 type mockMessages struct {
 	addMessageFn    func(message *proto.Message)
 	pruneByHeightFn func(height uint64)
-	signalEventFn   func(message *proto.Message)
+	signalEventFn   func(messageType proto.MessageType, messageView *proto.View)
 
 	getValidMessagesFn func(
 		view *proto.View,
@@ -303,9 +303,9 @@ func (m mockMessages) PruneByHeight(height uint64) {
 	}
 }
 
-func (m mockMessages) SignalEvent(msg *proto.Message) {
+func (m mockMessages) SignalEvent(msgType proto.MessageType, view *proto.View) {
 	if m.signalEventFn != nil {
-		m.signalEventFn(msg)
+		m.signalEventFn(msgType, view)
 	}
 }
 

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -65,14 +65,10 @@ func (ms *Messages) AddMessage(message *proto.Message) {
 }
 
 // SignalEvent signals event
-func (ms *Messages) SignalEvent(message *proto.Message) {
-	ms.eventManager.signalEvent(
-		message.Type,
-		&proto.View{
-			Height: message.View.Height,
-			Round:  message.View.Round,
-		},
-	)
+func (ms *Messages) SignalEvent(messageType proto.MessageType, view *proto.View) {
+	ms.eventManager.signalEvent(messageType, &proto.View{
+		Height: view.Height,
+		Round:  view.Round})
 }
 
 // Close closes event manager

--- a/messages/messages_test.go
+++ b/messages/messages_test.go
@@ -399,7 +399,7 @@ func TestMessages_EventManager(t *testing.T) {
 	randomMessages := generateRandomMessages(numMessages, baseView, messageType)
 	for _, message := range randomMessages {
 		messages.AddMessage(message)
-		messages.SignalEvent(message)
+		messages.SignalEvent(message.Type, message.View)
 	}
 
 	// Wait for the subscription event to happen


### PR DESCRIPTION
# Description

Since we assumed that the number of messages would always be greater than zero in the case of a quorum, it could have caused panic.

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the relevant labels
- [ ] I have added sufficient documentation in code

