### PR TITLE
HasPrepareQuorum - log missing proposal only in prepare state

### DIFF
--- a/core/ibft.go
+++ b/core/ibft.go
@@ -1265,7 +1265,7 @@ func (i *IBFT) hasQuorumByMsgType(msgs []*proto.Message, msgType proto.MessageTy
 	case proto.MessageType_PREPREPARE:
 		return len(msgs) >= 1
 	case proto.MessageType_PREPARE:
-		return i.validatorManager.HasPrepareQuorum(i.state.getProposalMessage(), msgs)
+		return i.validatorManager.HasPrepareQuorum(i.state.getStateName(), i.state.getProposalMessage(), msgs)
 	case proto.MessageType_ROUND_CHANGE, proto.MessageType_COMMIT:
 		return i.validatorManager.HasQuorum(convertMessageToAddressSet(msgs))
 	default:

--- a/core/validator_manager.go
+++ b/core/validator_manager.go
@@ -89,9 +89,14 @@ func (vm *ValidatorManager) HasQuorum(sendersAddrs map[string]struct{}) bool {
 }
 
 // HasPrepareQuorum provides information on whether prepared messages have reached the quorum
-func (vm *ValidatorManager) HasPrepareQuorum(proposalMessage *proto.Message, msgs []*proto.Message) bool {
+func (vm *ValidatorManager) HasPrepareQuorum(stateName stateType, proposalMessage *proto.Message,
+	msgs []*proto.Message) bool {
 	if proposalMessage == nil {
-		vm.log.Error("HasPrepareQuorum - proposalMessage is not set")
+		// If the state is in prepare phase, the proposal must be set. Otherwise, just return false since
+		// this is a valid scenario e.g. proposal msg is received before prepare msg for the same view
+		if stateName == prepare {
+			vm.log.Error("HasPrepareQuorum - proposalMessage is not set")
+		}
 
 		return false
 	}


### PR DESCRIPTION
# Description

This PR fixing unnecessary logging when the HasPrepareQuorum is called. To check if we have a quorum of prepare msgs, we need to know the proposer, which is read from the proposal. In some cases HasPrepareQuorum can be called when the proposer is not set e.g. when the prepare messages for a certain view arrives before the preprepare msg for the same view, when the state is in the runNewRound phase. In that case we should just return false without logging an error. If the state is in the prepare phase the message should be logged since we expect proposal to be set.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have added sufficient documentation in code

