### PR TITLE
Bump the go version to 1.21

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.x
+          go-version: 1.21.x
 
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.x
+          go-version: 1.21.x
 
       - name: Checkout code
         uses: actions/checkout@v3
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.x
+          go-version: 1.21.x
 
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -53,7 +53,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.x
+          go-version: 1.21.x
 
       - name: Checkout code
         uses: actions/checkout@v3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/0xPolygon/go-ibft
 
-go 1.19
+go 1.21
 
 require (
 	github.com/armon/go-metrics v0.4.1


### PR DESCRIPTION
# Description

Bump the Go version to 1.21 and upgrade the GH actions versions to the latest ones.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have added sufficient documentation in code

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
