### PR TITLE
Consensus halt fix

### DIFF
--- a/core/ibft.go
+++ b/core/ibft.go
@@ -373,6 +373,7 @@ func (i *IBFT) RunSequence(ctx context.Context, h uint64) {
 			// The consensus cycle for the block height is finished.
 			// Stop all running worker threads
 			teardown()
+			i.insertBlock()
 
 			return
 		case <-ctxRound.Done():
@@ -553,10 +554,7 @@ func (i *IBFT) runStates(ctx context.Context) {
 		case commit:
 			timeout = i.runCommit(ctx)
 		case fin:
-			i.runFin()
-			//	Block inserted without any errors,
-			// sequence is complete
-			i.signalRoundDone(ctx)
+			i.runFin(ctx)
 
 			return
 		}
@@ -960,10 +958,15 @@ func (i *IBFT) handleCommit(view *proto.View) bool {
 }
 
 // runFin runs the fin state (block insertion)
-func (i *IBFT) runFin() {
+func (i *IBFT) runFin(ctx context.Context) {
 	i.log.Debug("enter: fin state")
 	defer i.log.Debug("exit: fin state")
 
+	i.signalRoundDone(ctx)
+}
+
+// insertBlock inserts the block
+func (i *IBFT) insertBlock() {
 	// Insert the block to the node's underlying
 	// blockchain layer
 	i.backend.InsertProposal(

--- a/core/ibft_test.go
+++ b/core/ibft_test.go
@@ -1080,19 +1080,20 @@ func TestRunCommit(t *testing.T) {
 			i.startRound(ctx)
 
 			i.wg.Wait()
+			i.insertBlock()
 
 			// Make sure the node changed the state to fin
-			assert.Equal(t, fin, i.state.name)
+			require.Equal(t, fin, i.state.name)
 
 			// Make sure the inserted proposal was the one present
-			assert.Equal(t, insertedProposal, correctRoundMessage.proposal.RawProposal)
+			require.Equal(t, insertedProposal, correctRoundMessage.proposal.RawProposal)
 
 			// Make sure the inserted committed seals were correct
-			assert.Equal(t, insertedCommittedSeals, committedSeals)
+			require.Equal(t, insertedCommittedSeals, committedSeals)
 
 			// Make sure the proper done channel was notified
 			wg.Wait()
-			assert.True(t, doneReceived)
+			require.True(t, doneReceived)
 		},
 	)
 }


### PR DESCRIPTION
# Description

Some clients reported an issue where consensus will halt from time to time when nodes are under heavy load.

What happened was that, round lasted longer, almost the same as the round timeout, because the nodes were under stress test, so round expired and insert proposal happened at the same time. Unfortunatelly, round expired channel got notified while proposal was being inserted into chain. This created a strange situation, where block was inserted to chain, but rounds kept changing (round change was happening after this), even though porposal got inserted. This caused consensus to halt, and stop producing blocks.

The solution was provided by @lazartravica, and the fix was quite easy. When the quorum for commit messages is hit, and the node is in `fin` state (meaning it accepted the proposal, and will now insert it to chain), `roundDone` channel will be hit immediately, and porposal will be inserted after that. This means that round expired will not be hit while we are inserting proposal, since before this fix `roundDone` was hit only after the block was inserted, so if InsertProposal lasts a bit longer there is a chance that round timeout can be hit while the node is inserting block.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [x] I have added sufficient documentation in code